### PR TITLE
Add Move, Copy and PWD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,8 @@ mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
 
 UPROGS=\
 	$U/_cat\
+	$U/_copy\
+	$U/_move\
 	$U/_echo\
 	$U/_forktest\
 	$U/_grep\

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ UPROGS=\
 	$U/_cat\
 	$U/_copy\
 	$U/_move\
+	$U/_pwd\
 	$U/_echo\
 	$U/_forktest\
 	$U/_grep\

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_cwd(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_cwd]	  sys_cwd,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_cwd    22

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -5,6 +5,7 @@
 #include "memlayout.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "fs.h"
 
 uint64
 sys_exit(void)
@@ -93,12 +94,11 @@ sys_uptime(void)
 uint64
 sys_cwd(void)
 {
-  uint64 buf;
-  int size;
-  argaddr(0, &buf);
-  argint(2, &size);
-  
+  char buf[512];
+  struct dirent de;
   struct inode *pwd = myproc()->cwd;
-  printf("Current working directory is: %d\n", pwd);
+  readi(pwd, 0, (uint64)&de, 0, sizeof(de));
+  strncpy(buf, de.name, sizeof(de.name));
+  printf("Current PWD is: %s", buf);
   return 0;
 }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -89,3 +89,16 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+uint64
+sys_cwd(void)
+{
+  uint64 buf;
+  int size;
+  argaddr(0, &buf);
+  argint(2, &size);
+  
+  struct inode *pwd = myproc()->cwd;
+  printf("Current working directory is: %d\n", pwd);
+  return 0;
+}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -91,14 +91,22 @@ sys_uptime(void)
   return xticks;
 }
 
+//returns the path of the cwd inode stored within myproc() by getting its dirent name,
+//and copies it out to user space to a user provided buffer.
 uint64
 sys_cwd(void)
 {
-  char buf[512];
+  int size;
+  uint64 addr;
+  argaddr(0, &addr);
+  argint(1, &size);
+
   struct dirent de;
   struct inode *pwd = myproc()->cwd;
+  pagetable_t pagetable = myproc()->pagetable;
   readi(pwd, 0, (uint64)&de, 0, sizeof(de));
-  strncpy(buf, de.name, sizeof(de.name));
-  printf("Current PWD is: %s", buf);
-  return 0;
+  if(sizeof(de.name) > size){
+  	return -1;
+  }
+  return copyout(pagetable, addr, de.name, sizeof(de.name));
 }

--- a/user/copy.c
+++ b/user/copy.c
@@ -5,6 +5,12 @@
 
 char buf[2048];
 
+/*
+* Usage: copy /source_file /destination_file
+* Opens the source_file for reading, copies over content 
+* to a string buffer which is then written to the destination file.
+*/
+
 int
 main(int argc, char *argv[])
 {

--- a/user/copy.c
+++ b/user/copy.c
@@ -38,7 +38,7 @@ main(int argc, char *argv[])
 		}
 	}
 	if(n < 0) {
-		printf("Unable to read source file");
+		fprintf(2, "Unable to read source file");
 		exit(1);
 	}
 

--- a/user/copy.c
+++ b/user/copy.c
@@ -1,0 +1,42 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+char buf[2048];
+
+int
+main(int argc, char *argv[])
+{
+	int source, destination, n;
+	
+	if (argc <= 1){
+		fprintf(2, "Usage: /copy file_source file_destination\n");
+		exit(1);
+	} 
+
+	if ((source = open(argv[1], O_RDONLY)) == 0) {
+		fprintf(2, "copy: unable to open source file: %s", argv[1]);
+		exit(1);
+	}
+
+	if ((destination = open(argv[2], O_WRONLY)) == 0) {
+		fprintf(2, "copy: unable to open destination file: %s", argv[2]);
+		exit(1);
+	}
+
+	while((n = read(source, buf, sizeof(buf))) > 0) {
+		if (write(destination, buf, n) != n) {
+			fprintf(2, "copy: unable to copy to destination file: %s from source file %s", argv[2], argv[1]);
+			exit(1);
+		}
+	}
+	if(n < 0) {
+		printf("Unable to read source file");
+		exit(1);
+	}
+
+	close(source);
+	close(destination);
+	exit(0);
+}

--- a/user/move.c
+++ b/user/move.c
@@ -3,23 +3,29 @@
 #include "kernel/fcntl.h"
 #include "user/user.h"
 
-char buf[2048];
-
 int
 main(int argc, char *argv[])
 {
 	int source;
 	
 	if (argc <= 1){
-		printf("Usage: rm source destination...\n");
+		fprintf(2, "Usage: /move file_source dir_destination...\n");
 		exit(1);
 	} 
 
 	if ((source = open(argv[1], O_RDONLY)) == 0) {
-		printf("Unable to open source file");
+		fprintf(2, "move: Unable to open source file %s\n", argv[1]);
 		exit(1);
 	}
 
-	dup(source);
-	exit(1);
+	char *destination = malloc(strlen(argv[1]) + strlen(argv[2]) + 2);
+	strcpy(destination, argv[2]);
+	destination[strlen(argv[2])] = '/';
+	strcpy( destination + strlen(argv[2]) + 1, argv[1]);
+	if (link(argv[1], destination) < 0) {
+		fprintf(2, "move: link failed %s\n", destination);
+		exit(1);
+	}
+	unlink(argv[1]);
+	exit(0);
 }

--- a/user/move.c
+++ b/user/move.c
@@ -1,0 +1,25 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+char buf[2048];
+
+int
+main(int argc, char *argv[])
+{
+	int source;
+	
+	if (argc <= 1){
+		printf("Usage: rm source destination...\n");
+		exit(1);
+	} 
+
+	if ((source = open(argv[1], O_RDONLY)) == 0) {
+		printf("Unable to open source file");
+		exit(1);
+	}
+
+	dup(source);
+	exit(1);
+}

--- a/user/move.c
+++ b/user/move.c
@@ -21,11 +21,12 @@ main(int argc, char *argv[])
 	char *destination = malloc(strlen(argv[1]) + strlen(argv[2]) + 2);
 	strcpy(destination, argv[2]);
 	destination[strlen(argv[2])] = '/';
-	strcpy( destination + strlen(argv[2]) + 1, argv[1]);
+	strcpy(destination + strlen(argv[2]) + 1, argv[1]);
 	if (link(argv[1], destination) < 0) {
 		fprintf(2, "move: link failed %s\n", destination);
 		exit(1);
 	}
 	unlink(argv[1]);
+	free(destination);
 	exit(0);
 }

--- a/user/move.c
+++ b/user/move.c
@@ -3,6 +3,14 @@
 #include "kernel/fcntl.h"
 #include "user/user.h"
 
+/*
+* Usage: move /source_file /directory_destination
+* Takes in a source_file and moves it to the directory_destination.
+* Uses link and unlink to create a reference file pointing to the data
+* of the source file, moving the reference file into the directory, 
+* and unlinking the original file.
+*/
+
 int
 main(int argc, char *argv[])
 {

--- a/user/pwd.c
+++ b/user/pwd.c
@@ -3,9 +3,20 @@
 #include "kernel/fcntl.h"
 #include "user/user.h"
 
+/*
+* Given a buffer and size, calls a system call cwd 
+* that writes the current working directory that is 
+* found in myproc()->cwd to a user space buffer.
+*/
+
 int
 main(int argc, char *argv[])
 {
-	cwd();
+	char *buf = malloc(200);
+	if (cwd(buf, 200) < 0) {
+		fprintf(2, "pwd: unable to print out current working directory\n");
+		exit(1);
+	}
+	printf("The current working directory is: %s\n", buf);
 	exit(0);
 }

--- a/user/pwd.c
+++ b/user/pwd.c
@@ -1,0 +1,12 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+	char buf[200] = "hello";
+	cwd(buf, 200);
+	exit(0);
+}

--- a/user/pwd.c
+++ b/user/pwd.c
@@ -6,7 +6,6 @@
 int
 main(int argc, char *argv[])
 {
-	char buf[200] = "hello";
-	cwd(buf, 200);
+	cwd();
 	exit(0);
 }

--- a/user/user.h
+++ b/user/user.h
@@ -22,7 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
-int cwd(const char*, int size);
+int cwd(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -22,7 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
-int cwd(void);
+int cwd(const char*, int);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int cwd(const char*, int size);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("cwd");


### PR DESCRIPTION
Copy.c:

Copies the content of one text file to another text file. To test this, inside the os create two text files using the echo command and you can do /copy /source_file /destination_file to copy the contents of the source file to the destination file. 
Example commands to test this:
echo "" > empty.txt 
echo "Hello World! Spread this message to other text files" > hello.txt
copy hello.txt empty.txt
cat empty.txt
You should see that empty.txt now contains the text within hello.txt. If you do ls, the file sizes are also the same meaning all the content was copied. If you have any existing text in the destination file, it will be overwritten and copied over. This can be a suggested change.

Move.c

Moves a specified file to another directory. To test this, you can create a simple text file and a directory, then you can do /move /source_file /directory to move the file to the new directory. 
Example commands to test this:
echo "New Directory Unlocked" > moved.txt
mkdir newdir
move moved.txt newdir
You should now see that moved.txt is no longer contained in the root directory, but in whichever directory you specified. You cannot move a file that has the same name as an existing file inside the new directory.

Pwd.c

Prints the current working directory that is found within myproc(). For now this is a little buggy and doesn't print the path of a new directory. This is being worked on. To test this simply run pwd and the output should be '.' if ran in the root directory. 