### PR TITLE
added comm utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
 
 UPROGS=\
 	$U/_cat\
+	$U/_comm\
 	$U/_echo\
 	$U/_forktest\
 	$U/_grep\
@@ -128,14 +129,15 @@ UPROGS=\
 	$U/_rm\
 	$U/_sh\
 	$U/_stressfs\
+	$U/_testcomm\
 	$U/_usertests\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
 
-fs.img: mkfs/mkfs README.md $(UPROGS)
-	mkfs/mkfs fs.img README.md $(UPROGS)
-
+fs.img: mkfs/mkfs README.md text1.txt text2.txt $(UPROGS)
+	mkfs/mkfs fs.img README.md text1.txt text2.txt $(UPROGS) 
+	
 -include kernel/*.d user/*.d
 
 clean: 

--- a/text1.txt
+++ b/text1.txt
@@ -1,0 +1,6 @@
+apple
+banana
+grape
+orange
+pineapple
+raspberries

--- a/text2.txt
+++ b/text2.txt
@@ -1,0 +1,4 @@
+banana
+kiwi
+orange
+pomelo

--- a/user/comm.c
+++ b/user/comm.c
@@ -1,0 +1,96 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+
+/*
+*Prints the unique lines from two sorted files and common lines from both into 3 columns.
+*1st column contains lines unique to the first file
+*2nd column contains lines unique to the second file
+*3rd column conatins lines common to both
+*Run /testcomm for tests (stored in testcomm.c) and to run comm: /comm [optional flag] file1 file2
+*/
+void comm(const char *path1, const char *path2, int flag) {
+	char *line1 = ((void *) 0);
+	char *line2 = ((void *) 0);
+	uint len1 = 0;
+	uint len2 = 0;
+	int file1 = open(path1, O_RDONLY);
+	int file2 = open(path2, O_RDONLY);
+
+	if (file1 == -1 || file2 == -1) {
+		fprintf(2, "Error opening file.\n");
+	}
+	
+	int r1 = getline(&line1, &len1, file1); 
+	int r2 = getline(&line2, &len2, file2); 
+
+	while (1) {
+		if (r1 <= 0 || r2 <= 0) {
+			break;
+		}
+		int cmp = strcmp(line1, line2);
+		
+		//line is unique to file 1
+		if (cmp < 0) {				
+			if (flag != 1) {
+				printf("%s", line1);
+			}
+			r1 = getline(&line1, &len1, file1);
+		//line is unique to file 2
+		} else if (cmp > 0) {	
+			if (flag != 2) {
+				printf("\t%s", line2);
+			}
+			r2 = getline(&line2, &len2, file2);
+		//line common to both files
+		} else {					
+			if (flag != 3) {		
+				printf("\t\t%s", line1);
+			}
+			r1 = getline(&line1, &len1, file1);
+			r2 = getline(&line2, &len2, file2);
+		}
+	}
+	//print remaining lines if any
+	while (r1 != 0 && flag != 1) {
+		printf("%s", line1);
+		r1 = getline(&line1, &len1, file1);
+	}
+	while (r2 != 0 && flag != 2) {
+		printf("\t%s", line1);
+		r2 = getline(&line2, &len2, file2);
+	}
+	free(line1);
+	free(line2);
+}
+
+int main(int argc, char* argv[]) {
+	if (argc <= 2) {
+		printf("Usage: comm [-1 | -2 | -3] file1 file2\n");
+		return 1;
+	}
+	//check for flags
+	//-1: 1st column omitted (lines unique to file 1).
+	//-2: 2nd column ommited (lines unique to file 2).
+	//-3: 3rd column ommitted (lines common to both files).
+	int flag = 0;
+	char *flag_str = argv[1];
+
+	if (*flag_str == '-') {
+		flag_str++;
+		if (*flag_str == '1') {
+			flag = 1;
+		} else if (*flag_str == '2') {
+			flag = 2;
+		} else if (*flag_str == '3') {
+			flag = 3;
+		} else {
+			printf("invalid flags\n");
+		}
+		comm(argv[2], argv[3], flag);		
+	} else {
+		comm(argv[1], argv[2], 0);
+	}
+	return 0;
+}

--- a/user/testcomm.c
+++ b/user/testcomm.c
@@ -1,0 +1,58 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+
+//testing comm with two sorted files and no flags
+void comm_noflags() {
+	char *cmd[] = { "/comm", "text1.txt", "text2.txt", 0 };
+	exec(cmd[0], cmd);
+}
+
+//comm with -1 flag (1st column omitted)
+void comm_flag1() {
+	char *cmd[] = { "/comm", "-1", "text1.txt", "text2.txt", 0 };
+	exec(cmd[0], cmd);
+}
+
+//comm with -2 flag (2nd column omitted)
+void comm_flag2() {
+	char *cmd[] = { "/comm", "-2", "text1.txt", "text2.txt", 0 };
+	exec(cmd[0], cmd);
+}
+
+//comm with -3 flag (3rd column omitted)
+void comm_flag3() {
+	char *cmd[] = { "/comm", "-3", "text1.txt", "text2.txt", 0 };
+	exec(cmd[0], cmd);
+}
+
+//testing no args
+void comm_noargs() {
+	char *cmd[] = { "/comm", 0 };
+	exec(cmd[0], cmd);
+}
+
+//test non-existent files
+void invalid_files() {
+	char *cmd[] = { "/comm", "hello.txt", "world.txt", 0 };
+	exec(cmd[0], cmd);
+}
+
+int main(void) {
+	//run 1 test at a time 
+	
+	comm_noflags();
+
+	//comm_flag1();
+
+	//comm_flag2();
+
+	//comm_flag3();
+
+	//comm_noargs();
+
+	//invalid_files();
+	
+	return 0;
+}


### PR DESCRIPTION
Added the comm utility which takes two sorted files and prints out lines unique to the first file in the 1st column, lines unique to the second file int the 2nd column, and lines common to both files in the 3rd column. 
Optional flags: 
-1 : omits first column from output
-2 : omits 2nd column from output
-3 : omits third column from output

Usage: /comm [-1 | -2 | -3] file1 file2
Files: comm.c and testcomm.c in user directory, text1.txt and text2.txt are the files used for testing