### PR TITLE
Add psh (shell rainbow) and pv (pipeviewer)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $U/usys.o : $U/usys.S
 $U/_forktest: $U/forktest.o $(ULIB)
 	# forktest has less library code linked in - needs to be small
 	# in order to be able to max out the proc table.
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o $U/umalloc.o $U/printf.o
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o $U/umalloc.o
 	$(OBJDUMP) -S $U/_forktest > $U/forktest.asm
 
 mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
@@ -116,6 +116,8 @@ mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
 .PRECIOUS: %.o
 
 UPROGS=\
+	$U/_about\
+	$U/_broken\
 	$U/_cat\
 	$U/_echo\
 	$U/_forktest\
@@ -125,9 +127,12 @@ UPROGS=\
 	$U/_ln\
 	$U/_ls\
 	$U/_mkdir\
+	$U/_psh\
+	$U/_pv\
 	$U/_rm\
 	$U/_sh\
 	$U/_stressfs\
+	$U/_testgetline\
 	$U/_usertests\
 	$U/_grind\
 	$U/_wc\

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,6 @@ mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
 .PRECIOUS: %.o
 
 UPROGS=\
-	$U/_about\
-	$U/_broken\
 	$U/_cat\
 	$U/_echo\
 	$U/_forktest\
@@ -133,7 +131,6 @@ UPROGS=\
 	$U/_rm\
 	$U/_sh\
 	$U/_stressfs\
-	$U/_testgetline\
 	$U/_usertests\
 	$U/_grind\
 	$U/_wc\

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,21 @@ $U/_forktest: $U/forktest.o $(ULIB)
 	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o $U/umalloc.o
 	$(OBJDUMP) -S $U/_forktest > $U/forktest.asm
 
+# Compile psh_accessories.c
+$U/psh_accessories.o: $U/psh_accessories.c
+	$(CC) $(CFLAGS) -c -o $U/psh_accessories.o $U/psh_accessories.c
+
+# Link _sh including psh_accessories.o
+$U/_sh: $U/sh.o $U/psh_accessories.o $(ULIB)
+	$(LD) $(LDFLAGS) -T $U/user.ld -o $U/_sh $U/sh.o $U/psh_accessories.o $(ULIB)
+	$(OBJDUMP) -S $U/_sh > $U/sh.asm
+	$(OBJDUMP) -t $U/_sh | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $U/sh.sym
+# Link _psh including psh_accessories.o
+$U/_psh: $U/psh.o $U/psh_accessories.o $(ULIB)
+	$(LD) $(LDFLAGS) -T $U/user.ld -o $U/_psh $U/psh.o $U/psh_accessories.o $(ULIB)
+	$(OBJDUMP) -S $U/_psh > $U/psh.asm
+	$(OBJDUMP) -t $U/_psh | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $U/psh.sym
+   
 mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
 	gcc -Werror -Wall -I. -o mkfs/mkfs mkfs/mkfs.c
 
@@ -136,8 +151,8 @@ UPROGS=\
 	$U/_wc\
 	$U/_zombie\
 
-fs.img: mkfs/mkfs README.md $(UPROGS)
-	mkfs/mkfs fs.img README.md $(UPROGS)
+fs.img: mkfs/mkfs README.md time-machine.txt $(UPROGS)
+	mkfs/mkfs fs.img README.md time-machine.txt $(UPROGS)	
 
 -include kernel/*.d user/*.d
 

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ UPROGS=\
 	$U/_mkdir\
 	$U/_psh\
 	$U/_pv\
+	$U/_pv_tests\
 	$U/_rm\
 	$U/_sh\
 	$U/_stressfs\

--- a/time-machine.txt
+++ b/time-machine.txt
@@ -1,0 +1,500 @@
+﻿
+The Time Machine
+An Invention
+
+by H. G. Wells
+
+
+
+
+CONTENTS
+
+ I Introduction
+ II The Machine
+ III The Time Traveller Returns
+ IV Time Travelling
+ V In the Golden Age
+ VI The Sunset of Mankind
+ VII A Sudden Shock
+ VIII Explanation
+ IX The Morlocks
+ X When Night Came
+ XI The Palace of Green Porcelain
+ XII In the Darkness
+ XIII The Trap of the White Sphinx
+ XIV The Further Vision
+ XV The Time Traveller’s Return
+ XVI After the Story
+ Epilogue
+
+
+
+
+ I.
+ Introduction
+
+
+The Time Traveller (for so it will be convenient to speak of him) was
+expounding a recondite matter to us. His pale grey eyes shone and
+twinkled, and his usually pale face was flushed and animated. The fire
+burnt brightly, and the soft radiance of the incandescent lights in the
+lilies of silver caught the bubbles that flashed and passed in our
+glasses. Our chairs, being his patents, embraced and caressed us rather
+than submitted to be sat upon, and there was that luxurious
+after-dinner atmosphere, when thought runs gracefully free of the
+trammels of precision. And he put it to us in this way—marking the
+points with a lean forefinger—as we sat and lazily admired his
+earnestness over this new paradox (as we thought it) and his fecundity.
+
+“You must follow me carefully. I shall have to controvert one or two
+ideas that are almost universally accepted. The geometry, for instance,
+they taught you at school is founded on a misconception.”
+
+“Is not that rather a large thing to expect us to begin upon?” said
+Filby, an argumentative person with red hair.
+
+“I do not mean to ask you to accept anything without reasonable ground
+for it. You will soon admit as much as I need from you. You know of
+course that a mathematical line, a line of thickness _nil_, has no real
+existence. They taught you that? Neither has a mathematical plane.
+These things are mere abstractions.”
+
+“That is all right,” said the Psychologist.
+
+“Nor, having only length, breadth, and thickness, can a cube have a
+real existence.”
+
+“There I object,” said Filby. “Of course a solid body may exist. All
+real things—”
+
+“So most people think. But wait a moment. Can an _instantaneous_ cube
+exist?”
+
+“Don’t follow you,” said Filby.
+
+“Can a cube that does not last for any time at all, have a real
+existence?”
+
+Filby became pensive. “Clearly,” the Time Traveller proceeded, “any
+real body must have extension in _four_ directions: it must have
+Length, Breadth, Thickness, and—Duration. But through a natural
+infirmity of the flesh, which I will explain to you in a moment, we
+incline to overlook this fact. There are really four dimensions, three
+which we call the three planes of Space, and a fourth, Time. There is,
+however, a tendency to draw an unreal distinction between the former
+three dimensions and the latter, because it happens that our
+consciousness moves intermittently in one direction along the latter
+from the beginning to the end of our lives.”
+
+“That,” said a very young man, making spasmodic efforts to relight his
+cigar over the lamp; “that . . . very clear indeed.”
+
+“Now, it is very remarkable that this is so extensively overlooked,”
+continued the Time Traveller, with a slight accession of cheerfulness.
+“Really this is what is meant by the Fourth Dimension, though some
+people who talk about the Fourth Dimension do not know they mean it. It
+is only another way of looking at Time. _There is no difference between
+Time and any of the three dimensions of Space except that our
+consciousness moves along it_. But some foolish people have got hold of
+the wrong side of that idea. You have all heard what they have to say
+about this Fourth Dimension?”
+
+“_I_ have not,” said the Provincial Mayor.
+
+“It is simply this. That Space, as our mathematicians have it, is
+spoken of as having three dimensions, which one may call Length,
+Breadth, and Thickness, and is always definable by reference to three
+planes, each at right angles to the others. But some philosophical
+people have been asking why _three_ dimensions particularly—why not
+another direction at right angles to the other three?—and have even
+tried to construct a Four-Dimensional geometry. Professor Simon Newcomb
+was expounding this to the New York Mathematical Society only a month
+or so ago. You know how on a flat surface, which has only two
+dimensions, we can represent a figure of a three-dimensional solid, and
+similarly they think that by models of three dimensions they could
+represent one of four—if they could master the perspective of the
+thing. See?”
+
+“I think so,” murmured the Provincial Mayor; and, knitting his brows,
+he lapsed into an introspective state, his lips moving as one who
+repeats mystic words. “Yes, I think I see it now,” he said after some
+time, brightening in a quite transitory manner.
+
+“Well, I do not mind telling you I have been at work upon this geometry
+of Four Dimensions for some time. Some of my results are curious. For
+instance, here is a portrait of a man at eight years old, another at
+fifteen, another at seventeen, another at twenty-three, and so on. All
+these are evidently sections, as it were, Three-Dimensional
+representations of his Four-Dimensioned being, which is a fixed and
+unalterable thing.
+
+“Scientific people,” proceeded the Time Traveller, after the pause
+required for the proper assimilation of this, “know very well that Time
+is only a kind of Space. Here is a popular scientific diagram, a
+weather record. This line I trace with my finger shows the movement of
+the barometer. Yesterday it was so high, yesterday night it fell, then
+this morning it rose again, and so gently upward to here. Surely the
+mercury did not trace this line in any of the dimensions of Space
+generally recognised? But certainly it traced such a line, and that
+line, therefore, we must conclude, was along the Time-Dimension.”
+
+“But,” said the Medical Man, staring hard at a coal in the fire, “if
+Time is really only a fourth dimension of Space, why is it, and why has
+it always been, regarded as something different? And why cannot we move
+in Time as we move about in the other dimensions of Space?”
+
+The Time Traveller smiled. “Are you so sure we can move freely in
+Space? Right and left we can go, backward and forward freely enough,
+and men always have done so. I admit we move freely in two dimensions.
+But how about up and down? Gravitation limits us there.”
+
+“Not exactly,” said the Medical Man. “There are balloons.”
+
+“But before the balloons, save for spasmodic jumping and the
+inequalities of the surface, man had no freedom of vertical movement.”
+
+“Still they could move a little up and down,” said the Medical Man.
+
+“Easier, far easier down than up.”
+
+“And you cannot move at all in Time, you cannot get away from the
+present moment.”
+
+“My dear sir, that is just where you are wrong. That is just where the
+whole world has gone wrong. We are always getting away from the present
+moment. Our mental existences, which are immaterial and have no
+dimensions, are passing along the Time-Dimension with a uniform
+velocity from the cradle to the grave. Just as we should travel _down_
+if we began our existence fifty miles above the earth’s surface.”
+
+“But the great difficulty is this,” interrupted the Psychologist. ’You
+_can_ move about in all directions of Space, but you cannot move about
+in Time.”
+
+“That is the germ of my great discovery. But you are wrong to say that
+we cannot move about in Time. For instance, if I am recalling an
+incident very vividly I go back to the instant of its occurrence: I
+become absent-minded, as you say. I jump back for a moment. Of course
+we have no means of staying back for any length of Time, any more than
+a savage or an animal has of staying six feet above the ground. But a
+civilised man is better off than the savage in this respect. He can go
+up against gravitation in a balloon, and why should he not hope that
+ultimately he may be able to stop or accelerate his drift along the
+Time-Dimension, or even turn about and travel the other way?”
+
+“Oh, _this_,” began Filby, “is all—”
+
+“Why not?” said the Time Traveller.
+
+“It’s against reason,” said Filby.
+
+“What reason?” said the Time Traveller.
+
+“You can show black is white by argument,” said Filby, “but you will
+never convince me.”
+
+“Possibly not,” said the Time Traveller. “But now you begin to see the
+object of my investigations into the geometry of Four Dimensions. Long
+ago I had a vague inkling of a machine—”
+
+“To travel through Time!” exclaimed the Very Young Man.
+
+“That shall travel indifferently in any direction of Space and Time, as
+the driver determines.”
+
+Filby contented himself with laughter.
+
+“But I have experimental verification,” said the Time Traveller.
+
+“It would be remarkably convenient for the historian,” the Psychologist
+suggested. “One might travel back and verify the accepted account of
+the Battle of Hastings, for instance!”
+
+“Don’t you think you would attract attention?” said the Medical Man.
+“Our ancestors had no great tolerance for anachronisms.”
+
+“One might get one’s Greek from the very lips of Homer and Plato,” the
+Very Young Man thought.
+
+“In which case they would certainly plough you for the Little-go. The
+German scholars have improved Greek so much.”
+
+“Then there is the future,” said the Very Young Man. “Just think! One
+might invest all one’s money, leave it to accumulate at interest, and
+hurry on ahead!”
+
+“To discover a society,” said I, “erected on a strictly communistic
+basis.”
+
+“Of all the wild extravagant theories!” began the Psychologist.
+
+“Yes, so it seemed to me, and so I never talked of it until—”
+
+“Experimental verification!” cried I. “You are going to verify _that_?”
+
+“The experiment!” cried Filby, who was getting brain-weary.
+
+“Let’s see your experiment anyhow,” said the Psychologist, “though it’s
+all humbug, you know.”
+
+The Time Traveller smiled round at us. Then, still smiling faintly, and
+with his hands deep in his trousers pockets, he walked slowly out of
+the room, and we heard his slippers shuffling down the long passage to
+his laboratory.
+
+The Psychologist looked at us. “I wonder what he’s got?”
+
+“Some sleight-of-hand trick or other,” said the Medical Man, and Filby
+tried to tell us about a conjuror he had seen at Burslem, but before he
+had finished his preface the Time Traveller came back, and Filby’s
+anecdote collapsed.
+
+
+
+
+ II.
+ The Machine
+
+
+The thing the Time Traveller held in his hand was a glittering metallic
+framework, scarcely larger than a small clock, and very delicately
+made. There was ivory in it, and some transparent crystalline
+substance. And now I must be explicit, for this that follows—unless his
+explanation is to be accepted—is an absolutely unaccountable thing. He
+took one of the small octagonal tables that were scattered about the
+room, and set it in front of the fire, with two legs on the hearthrug.
+On this table he placed the mechanism. Then he drew up a chair, and sat
+down. The only other object on the table was a small shaded lamp, the
+bright light of which fell upon the model. There were also perhaps a
+dozen candles about, two in brass candlesticks upon the mantel and
+several in sconces, so that the room was brilliantly illuminated. I sat
+in a low arm-chair nearest the fire, and I drew this forward so as to
+be almost between the Time Traveller and the fireplace. Filby sat
+behind him, looking over his shoulder. The Medical Man and the
+Provincial Mayor watched him in profile from the right, the
+Psychologist from the left. The Very Young Man stood behind the
+Psychologist. We were all on the alert. It appears incredible to me
+that any kind of trick, however subtly conceived and however adroitly
+done, could have been played upon us under these conditions.
+
+The Time Traveller looked at us, and then at the mechanism. “Well?”
+said the Psychologist.
+
+“This little affair,” said the Time Traveller, resting his elbows upon
+the table and pressing his hands together above the apparatus, “is only
+a model. It is my plan for a machine to travel through time. You will
+notice that it looks singularly askew, and that there is an odd
+twinkling appearance about this bar, as though it was in some way
+unreal.” He pointed to the part with his finger. “Also, here is one
+little white lever, and here is another.”
+
+The Medical Man got up out of his chair and peered into the thing.
+“It’s beautifully made,” he said.
+
+“It took two years to make,” retorted the Time Traveller. Then, when we
+had all imitated the action of the Medical Man, he said: “Now I want
+you clearly to understand that this lever, being pressed over, sends
+the machine gliding into the future, and this other reverses the
+motion. This saddle represents the seat of a time traveller. Presently
+I am going to press the lever, and off the machine will go. It will
+vanish, pass into future Time, and disappear. Have a good look at the
+thing. Look at the table too, and satisfy yourselves there is no
+trickery. I don’t want to waste this model, and then be told I’m a
+quack.”
+
+There was a minute’s pause perhaps. The Psychologist seemed about to
+speak to me, but changed his mind. Then the Time Traveller put forth
+his finger towards the lever. “No,” he said suddenly. “Lend me your
+hand.” And turning to the Psychologist, he took that individual’s hand
+in his own and told him to put out his forefinger. So that it was the
+Psychologist himself who sent forth the model Time Machine on its
+interminable voyage. We all saw the lever turn. I am absolutely certain
+there was no trickery. There was a breath of wind, and the lamp flame
+jumped. One of the candles on the mantel was blown out, and the little
+machine suddenly swung round, became indistinct, was seen as a ghost
+for a second perhaps, as an eddy of faintly glittering brass and ivory;
+and it was gone—vanished! Save for the lamp the table was bare.
+
+Everyone was silent for a minute. Then Filby said he was damned.
+
+The Psychologist recovered from his stupor, and suddenly looked under
+the table. At that the Time Traveller laughed cheerfully. “Well?” he
+said, with a reminiscence of the Psychologist. Then, getting up, he
+went to the tobacco jar on the mantel, and with his back to us began to
+fill his pipe.
+
+We stared at each other. “Look here,” said the Medical Man, “are you in
+earnest about this? Do you seriously believe that that machine has
+travelled into time?”
+
+“Certainly,” said the Time Traveller, stooping to light a spill at the
+fire. Then he turned, lighting his pipe, to look at the Psychologist’s
+face. (The Psychologist, to show that he was not unhinged, helped
+himself to a cigar and tried to light it uncut.) “What is more, I have
+a big machine nearly finished in there”—he indicated the
+laboratory—“and when that is put together I mean to have a journey on
+my own account.”
+
+“You mean to say that that machine has travelled into the future?” said
+Filby.
+
+“Into the future or the past—I don’t, for certain, know which.”
+
+After an interval the Psychologist had an inspiration. “It must have
+gone into the past if it has gone anywhere,” he said.
+
+“Why?” said the Time Traveller.
+
+“Because I presume that it has not moved in space, and if it travelled
+into the future it would still be here all this time, since it must
+have travelled through this time.”
+
+“But,” said I, “If it travelled into the past it would have been
+visible when we came first into this room; and last Thursday when we
+were here; and the Thursday before that; and so forth!”
+
+“Serious objections,” remarked the Provincial Mayor, with an air of
+impartiality, turning towards the Time Traveller.
+
+“Not a bit,” said the Time Traveller, and, to the Psychologist: “You
+think. _You_ can explain that. It’s presentation below the threshold,
+you know, diluted presentation.”
+
+“Of course,” said the Psychologist, and reassured us. “That’s a simple
+point of psychology. I should have thought of it. It’s plain enough,
+and helps the paradox delightfully. We cannot see it, nor can we
+appreciate this machine, any more than we can the spoke of a wheel
+spinning, or a bullet flying through the air. If it is travelling
+through time fifty times or a hundred times faster than we are, if it
+gets through a minute while we get through a second, the impression it
+creates will of course be only one-fiftieth or one-hundredth of what it
+would make if it were not travelling in time. That’s plain enough.” He
+passed his hand through the space in which the machine had been. “You
+see?” he said, laughing.
+
+We sat and stared at the vacant table for a minute or so. Then the Time
+Traveller asked us what we thought of it all.
+
+“It sounds plausible enough tonight,” said the Medical Man; “but wait
+until tomorrow. Wait for the common sense of the morning.”
+
+“Would you like to see the Time Machine itself?” asked the Time
+Traveller. And therewith, taking the lamp in his hand, he led the way
+down the long, draughty corridor to his laboratory. I remember vividly
+the flickering light, his queer, broad head in silhouette, the dance of
+the shadows, how we all followed him, puzzled but incredulous, and how
+there in the laboratory we beheld a larger edition of the little
+mechanism which we had seen vanish from before our eyes. Parts were of
+nickel, parts of ivory, parts had certainly been filed or sawn out of
+rock crystal. The thing was generally complete, but the twisted
+crystalline bars lay unfinished upon the bench beside some sheets of
+drawings, and I took one up for a better look at it. Quartz it seemed
+to be.
+
+“Look here,” said the Medical Man, “are you perfectly serious? Or is
+this a trick—like that ghost you showed us last Christmas?”
+
+“Upon that machine,” said the Time Traveller, holding the lamp aloft,
+“I intend to explore time. Is that plain? I was never more serious in
+my life.”
+
+None of us quite knew how to take it.
+
+I caught Filby’s eye over the shoulder of the Medical Man, and he
+winked at me solemnly.
+
+
+
+
+ III.
+ The Time Traveller Returns
+
+
+I think that at that time none of us quite believed in the Time
+Machine. The fact is, the Time Traveller was one of those men who are
+too clever to be believed: you never felt that you saw all round him;
+you always suspected some subtle reserve, some ingenuity in ambush,
+behind his lucid frankness. Had Filby shown the model and explained the
+matter in the Time Traveller’s words, we should have shown _him_ far
+less scepticism. For we should have perceived his motives: a
+pork-butcher could understand Filby. But the Time Traveller had more
+than a touch of whim among his elements, and we distrusted him. Things
+that would have made the fame of a less clever man seemed tricks in his
+hands. It is a mistake to do things too easily. The serious people who
+took him seriously never felt quite sure of his deportment; they were
+somehow aware that trusting their reputations for judgment with him was
+like furnishing a nursery with eggshell china. So I don’t think any of
+us said very much about time travelling in the interval between that
+Thursday and the next, though its odd potentialities ran, no doubt, in
+most of our minds: its plausibility, that is, its practical
+incredibleness, the curious possibilities of anachronism and of utter
+confusion it suggested. For my own part, I was particularly preoccupied
+with the trick of the model. That I remember discussing with the
+Medical Man, whom I met on Friday at the Linnæan. He said he had seen a
+similar thing at Tübingen, and laid considerable stress on the
+blowing-out of the candle. But how the trick was done he could not
+explain.
+
+The next Thursday I went again to Richmond—I suppose I was one of the
+Time Traveller’s most constant guests—and, arriving late, found four or
+five men already assembled in his drawing-room. The Medical Man was
+standing before the fire with a sheet of paper in one hand and his
+watch in the other. I looked round for the Time Traveller, and—“It’s
+half-past seven now,” said the Medical Man. “I suppose we’d better have
+dinner?”
+
+“Where’s——?” said I, naming our host.
+
+“You’ve just come? It’s rather odd. He’s unavoidably detained. He asks
+me in this note to lead off with dinner at seven if he’s not back. Says
+he’ll explain when he comes.”
+
+“It seems a pity to let the dinner spoil,” said the Editor of a
+well-known daily paper; and thereupon the Doctor rang the bell.
+
+The Psychologist was the only person besides the Doctor and myself who
+had attended the previous dinner. The other men were Blank, the Editor
+aforementioned, a certain journalist, and another—a quiet, shy man with
+a beard—whom I didn’t know, and who, as far as my observation went,
+never opened his mouth all the evening. There was some speculation at
+the dinner-table about the Time Traveller’s absence, and I suggested
+time travelling, in a half-jocular spirit. The Editor wanted that
+explained to him, and the Psychologist volunteered a wooden account of
+the “ingenious paradox and trick” we had witnessed that day week. He
+was in the midst of his exposition when the door from the corridor
+opened slowly and without noise. I was facing the door, and saw it
+first. “Hallo!” I said. “At last!” And the door opened wider, and the
+Time Traveller stood before us. I gave a cry of surprise. “Good
+heavens! man, what’s the matter?” cried the Medical Man, who saw him
+next. And the whole tableful turned towards the door.
+
+He was in an amazing plight. His coat was dusty and dirty, and smeared
+with green down the sleeves; his hair disordered, and as it seemed to
+me greyer—either with dust and dirt or because its colour had actually
+faded. His face was ghastly pale; his chin had a brown cut on it—a cut
+half-healed; his expression was haggard and drawn, as by intense
+suffering. For a moment he hesitated in the doorway, as if he had been
+dazzled by the light. Then he came into the room. He walked with just
+such a limp as I have seen in footsore tramps. We stared at him in
+silence, expecting him to speak.
+
+He said not a word, but came painfully to the table, and made a motion
+towards the wine. The Editor filled a glass of champagne, and pushed it
+towards him. He drained it, and it seemed to do him good: for he looked
+round the table, and the ghost of his old smile flickered across his
+face. “What on earth have you been up to, man?” said the Doctor. The
+Time Traveller did not seem to hear. “Don’t let me disturb you,” he
+said, with a certain faltering articulation. “I’m all right.” He
+stopped, held out his glass for more, and took it off at a draught.
+“That’s good,” he said. His eyes grew brighter, and a faint colour came
+into his cheeks. His glance flickered over our faces with a certain
+dull approval, and then went round the warm and comfortable room. Then
+he spoke again, still as it were feeling his way among his words. “I’m
+going to wash and dress, and then I’ll come down and explain things....
+Save me some of that mutton. I’m starving for a bit of meat.”
+
+He looked across at the Editor, who was a rare visitor, and hoped he
+was all right. The Editor began a question. “Tell you presently,” said
+the Time Traveller. “I’m—funny! Be all right in a minute.”
+
+He put down his glass, and walked towards the staircase door.

--- a/user/init.c
+++ b/user/init.c
@@ -23,14 +23,22 @@ main(void)
   dup(0);  // stdout
   dup(0);  // stderr
 
-  printf(" __________________\n");
-  printf("< Welcome to FogOS >\n");
-  printf(" ------------------\n");
-  printf("        \\   ^__^\n");
-  printf("         \\  (**)\\_______\n");
-  printf("            (__)\\       )\\/\\\n");
-  printf("             U  ||----w |\n");
-  printf("                ||     ||\n");
+  // create /tmp for psh line_count storage
+  if (open("/tmp", O_RDONLY) < 0) {
+    if (mkdir("/tmp") < 0) {
+  	  printf("init: failed to create /tmp\n");
+    }
+  }
+
+
+  // create line_count store for psh
+  int psh_fd = open("/tmp/line_color", O_WRONLY | O_CREATE);
+  if (psh_fd >= 0) {
+  	write(psh_fd, 0, 1);
+  	close(psh_fd);
+  } else {
+  	printf("init: failed to create /tmp/line_color\n");
+  }
 
   for(;;){
     printf("init: starting sh\n");

--- a/user/psh.c
+++ b/user/psh.c
@@ -1,0 +1,62 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fs.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+
+/**
+* psh (pride shell)
+* run `psh` to toggle
+*/
+
+int
+main(int argc, char *argv)
+{
+	char *filename = "/tmp/psh_toggle";
+	int fd;
+	char buf[2];
+
+	fd = open(filename, O_RDWR);
+
+	if (fd < 0) {
+		fd = open(filename, O_CREATE | O_RDWR);
+		if (fd < 0) {
+			printf("Error: failed to create psh_toggle file.\n");
+			exit(1);
+		}
+		buf[0] = '1';
+		buf[1] = '\0';
+		write(fd, buf, 1);
+		printf("psh enabled! happy pride!\n");
+
+	} else {
+		read(fd, buf, 1);
+		buf[1] = '\0';
+
+		close(fd);
+
+		int bit = buf[0] - '0';
+
+		bit = bit ^ 1;
+
+		fd = open(filename, O_WRONLY);
+		if (fd < 0) {
+			printf("Error: failed to reopen psh_toggle\n");
+			exit(1);
+		}
+
+		buf[0] = bit + '0';
+		write(fd, buf, 1);
+
+		if (bit == 1) {
+			printf("psh enabled! happy pride!\n");
+		} else {
+		    printf("\033[0mpsh disabled. you really afraid of rainbows? :(\n", buf[0]);
+		}
+
+
+	}
+
+	close(fd);
+	exit(0);
+}

--- a/user/psh.c
+++ b/user/psh.c
@@ -3,15 +3,17 @@
 #include "kernel/fs.h"
 #include "user/user.h"
 #include "kernel/fcntl.h"
+#include "user/psh.h"
 
 /**
-* psh (pride shell)
+* psh (pride shell) executable toggle
 * run `psh` to toggle
 */
 
-int
-main(int argc, char *argv)
-{
+#define OPEN_MSG "🌈 psh enabled! happy pride! 🌈"
+
+int main (int argc, char *argv) {
+
 	char *filename = "/tmp/psh_toggle";
 	int fd;
 	char buf[2];
@@ -27,7 +29,9 @@ main(int argc, char *argv)
 		buf[0] = '1';
 		buf[1] = '\0';
 		write(fd, buf, 1);
-		printf("psh enabled! happy pride!\n");
+
+		printf("%s\n", OPEN_MSG);
+		set_color();
 
 	} else {
 		read(fd, buf, 1);
@@ -35,9 +39,13 @@ main(int argc, char *argv)
 
 		close(fd);
 
-		int bit = buf[0] - '0';
+		// i wanted to do some bitwise stuff here (i was feeling special)
+		// it just does an XOR to either turn it on or off
+		// (if the number in the toggle file is 1 (on), it changes to 0 (off), and vice versa)
 
-		bit = bit ^ 1;
+		int toggle = buf[0] - '0';
+
+		toggle = toggle ^ 1;
 
 		fd = open(filename, O_WRONLY);
 		if (fd < 0) {
@@ -45,11 +53,12 @@ main(int argc, char *argv)
 			exit(1);
 		}
 
-		buf[0] = bit + '0';
+		buf[0] = toggle + '0';
 		write(fd, buf, 1);
 
-		if (bit == 1) {
-			printf("psh enabled! happy pride!\n");
+		if (toggle == 1) {
+			printf("%s\n", OPEN_MSG);
+			set_color();
 		} else {
 		    printf("\033[0mpsh disabled. you really afraid of rainbows? :(\n", buf[0]);
 		}
@@ -59,4 +68,5 @@ main(int argc, char *argv)
 
 	close(fd);
 	exit(0);
+	
 }

--- a/user/psh.h
+++ b/user/psh.h
@@ -1,0 +1,17 @@
+// check which line to determine color, rets line number
+int read_line_count();
+
+// updates line num for color
+void save_line_count(int line_count);
+
+// checks if psh is enabled, rets 1 for true, 0 for false
+int is_psh_enabled();
+
+// resets color to white
+void reset_color();
+
+// updates color
+void increment_color();
+
+// sets the color
+void set_color();

--- a/user/psh_accessories.c
+++ b/user/psh_accessories.c
@@ -1,0 +1,126 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fs.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+#include "user/psh.h"
+
+//
+//	psh accessory functions for sh.c (keeps things clean)
+//
+
+
+// 8-Bit color array
+char *colors_256[] = {
+
+    "\033[38;5;196m",  // Red
+    "\033[38;5;202m",  // Light Red/Orange
+    "\033[38;5;208m",  // Orange
+    "\033[38;5;214m",  // Light Orange
+    "\033[38;5;226m",  // Yellow
+    "\033[38;5;190m",  // Light Yellow/Green
+    "\033[38;5;46m",   // Green
+    "\033[38;5;83m",   // Light Green
+    "\033[38;5;51m",   // Cyan
+    "\033[38;5;81m",   // Light Cyan
+    "\033[38;5;111m",  // Sky Blue (Lighter Blue)
+    "\033[38;5;69m",   // Teal/Light Blue
+    "\033[38;5;33m",   // Dark Blue
+    "\033[38;5;201m",  // Magenta
+    "\033[38;5;207m",  // Light Magenta
+	
+};
+
+
+/*
+*
+* read_line_count() -> returns the current line number for color choice
+*
+*/
+int
+read_line_count()
+{
+	int fd, line_count = 0;
+	fd = open("/tmp/line_count", O_RDONLY);
+	if (fd >= 0) {
+		read(fd, &line_count, sizeof(line_count));
+		close(fd);
+	}
+	return line_count;
+}
+
+/*
+*
+* save_line_count(int line_count) -> takes the next line count and saves it to the counter file
+*
+*/
+void
+save_line_count(int line_count)
+{
+	int fd = open("/tmp/line_count", O_WRONLY | O_CREATE);
+	write(fd, &line_count, sizeof(line_count));
+	close(fd);
+}
+
+/*
+*
+* is_psh_enabled() -> checks if psh is enabled (by calling `psh`), returns 1 if enabled, 0 if not 
+*
+*/
+
+int
+is_psh_enabled()
+{
+	int fd;
+	char buf[2];
+
+	fd = open("/tmp/psh_toggle", O_RDONLY);
+
+	if (fd < 0) {
+		return 0;
+	}
+
+	read(fd, buf, 1);
+	buf[1] = '\0';
+
+	close(fd);
+
+	return (buf[0] == '1') ? 1 : 0;
+}
+
+
+/*
+*
+* reset_color() -> resets the terminal color to white
+*
+*/
+
+void
+reset_color()
+{
+	printf("\033[0m");
+}
+
+
+
+/*
+*
+* set_next_color() -> moves color to next in `colors_256[]`, updates current line number
+*
+*/
+void increment_color() {
+	if (is_psh_enabled()) {
+		set_color();
+	} else {
+		reset_color();
+	}
+}
+
+void set_color() {
+	int line_count = read_line_count();
+	printf("%s", colors_256[line_count % (sizeof(colors_256) / sizeof(colors_256[0]) - 1)]);
+	line_count++;
+	save_line_count(line_count);
+}
+
+

--- a/user/pv.c
+++ b/user/pv.c
@@ -29,6 +29,13 @@ main(int argc, char *argv[])
 	int bytes_read;
 	unsigned int total_bytes = 0;
 	int start_time = uptime();
+	struct stat st;
+
+
+	if (fstat(0, &st) >= 0 && st.type == T_DEVICE) {
+		fprintf(2, "pv: no input piped\n");
+		exit(1);
+	}
 
 
 	while ((bytes_read = read(0, buffer, sizeof(buffer))) > 0) {

--- a/user/pv.c
+++ b/user/pv.c
@@ -1,0 +1,62 @@
+/**
+ * Implementation of pipe viewer (pv) for xv6
+ *
+ * This program reads data from standard input and writes it to standard output,
+ * while displaying progress information (bytes transferred and transfer rate)
+ * on standard error.
+ */
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fs.h"
+#include "user/user.h"
+
+#define BUFFER_SIZE 512
+
+/**
+ * Main function for the pipe viewer
+ *
+ * Reads data from standard input in chunks, writes it to standard output,
+ * and displays progress information on standard error.
+ *
+ * @param argc Number of command-line arguments
+ * @param argv Array of command-line argument strings
+ * @return 0 on success, 1 on error
+ */
+int
+main(int argc, char *argv[])
+{
+	char buffer[BUFFER_SIZE];
+	int bytes_read;
+	unsigned int total_bytes = 0;
+	int start_time = uptime();
+
+
+	while ((bytes_read = read(0, buffer, sizeof(buffer))) > 0) {
+		if (write(1, buffer, bytes_read) != bytes_read) {
+			fprintf(2, "pv: write error\n");
+			exit(1);
+		}
+
+		total_bytes += bytes_read;
+
+		int elapsed_ticks = uptime() - start_time;
+
+		if (elapsed_ticks == 0) {
+			elapsed_ticks = 1;
+		}
+
+		int rate = total_bytes / elapsed_ticks;
+
+		fprintf(2, "\r%d bytes transferred, %d bytes/tick", total_bytes, rate);
+		 
+	}
+
+	if (bytes_read < 0) {
+		fprintf(2, "pv: read error\n");
+		exit(1);
+	}
+
+	fprintf(2, "\n");
+	exit(0);
+
+}

--- a/user/pv_tests.c
+++ b/user/pv_tests.c
@@ -1,0 +1,135 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+
+#define BUFFER_SIZE 1024
+#define TEST_FILE "test_input.txt"
+#define OUTPUT_FILE "test_output.txt"
+
+
+/**
+* writes a test file given contents.
+* 
+* @param content What to write to file
+*/
+void
+create_test_file(char *content)
+{
+
+	// delete file if exists
+	struct stat st;
+
+    if (stat(TEST_FILE, &st) == 0) {
+    	printf("File exists, deleting file.\n");
+    	if (unlink(TEST_FILE) < 0) {
+    		printf("Failed to delete file.\n");
+    		exit(1);
+    	}
+    } 
+
+	// create if file dne
+    int fd = open(TEST_FILE, O_CREATE | O_WRONLY);
+    if (fd < 0) {
+        printf("Failed to create test file\n");
+        exit(1);
+    }
+    
+    write(fd, content, strlen(content));
+    close(fd);
+}
+
+
+/**
+* checks if pv correctly transfers data from input to output.
+*/
+void
+test_pv_data_transfer()
+{
+    char *test_content = "This is a test file for pv.\n";
+    create_test_file(test_content);
+
+    int pid = fork();
+    if (pid == 0) { // child process
+    
+        // closes stdin/out and replaces them w the test files
+        // (so pv doesn't try to read from terminal + print pv output)
+        close(0);
+        open(TEST_FILE, O_RDONLY);
+        close(1);
+        open(OUTPUT_FILE, O_CREATE | O_WRONLY);
+        
+		//  name and a null pointer to terminate the list
+        char *argv[] = {"pv", 0};
+        exec("pv", argv);	// replaces process w pv, so shouldnt reach exit
+        exit(1);  
+    } else { // parent process
+        wait(0);
+       
+        int fd = open(OUTPUT_FILE, O_RDONLY);
+        if (fd < 0) {
+            printf("FAIL: Could not open output file\n");
+            exit(1);
+        }
+
+		// reads output into buf
+        char buf[BUFFER_SIZE];
+        
+        read(fd, buf, BUFFER_SIZE);
+        close(fd);
+
+		// makes sure the test was copied correctly
+        if (strcmp(buf, test_content) != 0) {
+            printf("FAIL: Output does not match input\nTest content: '%s'\nOutput: '%s'\n", test_content, buf);
+            exit(1);
+        }
+
+        printf("PASS: pv data transfer test\n");
+    }
+}
+
+/**
+* runs pv and checks if it exits successfully. 
+*/
+void
+test_pv_progress_output()
+{
+    char *test_content = "This is a longerrrrrrrrrrrrrrrrr test file for pv.\n";	//TODO why does this print but not ^
+    create_test_file(test_content);
+
+    int pid = fork();
+    if (pid == 0) { // child
+    	// replace std in w test file
+        close(0);
+        open(TEST_FILE, O_RDONLY);
+
+        // run pv on test file
+        char *argv[] = {"pv", 0};
+        exec("pv", argv);
+        exit(1);  
+    } else { // parent 
+    	// child's exit info
+        int status;
+        wait(&status);
+ 
+		//extracts exit code stored in wait (I looked this up lol)
+        if ((status & 0xff) != 0) {
+            printf("FAIL: pv exited with non-zero status\n");
+            exit(1);
+        }
+		// ! doesn't distinguish between normal non-0 exits and errors !
+        printf("PASS: pv progress output test\n");
+    }
+}
+
+int
+main()
+{
+    printf("Running pv tests...\n");
+
+    test_pv_data_transfer();
+    test_pv_progress_output();
+
+    printf("All tests completed!\n");
+    exit(0);
+}

--- a/user/sh.c
+++ b/user/sh.c
@@ -268,11 +268,6 @@ main(void)
       	fprintf(2, "cannot cd %s\n", buf + 3);
       
       continue;
-      // 
-      // buf[strlen(buf)-1] = 0;  // chop \n
-      // if(chdir(buf+3) < 0)
-      //   fprintf(2, "cannot cd %s\n", buf+3);
-      // continue;
     }
     if(fork1() == 0)
       runcmd(parsecmd(buf));

--- a/user/sh.c
+++ b/user/sh.c
@@ -54,6 +54,94 @@ void panic(char*);
 struct cmd *parsecmd(char*);
 void runcmd(struct cmd*) __attribute__((noreturn));
 
+// psh
+
+char *colors_256[] = {
+
+    "\033[38;5;196m",  // Red
+    "\033[38;5;202m",  // Light Red/Orange
+    "\033[38;5;208m",  // Orange
+    "\033[38;5;214m",  // Light Orange
+    "\033[38;5;226m",  // Yellow
+    "\033[38;5;190m",  // Light Yellow/Green
+    "\033[38;5;46m",   // Green
+    "\033[38;5;83m",   // Light Green
+    "\033[38;5;51m",   // Cyan
+    "\033[38;5;81m",   // Light Cyan
+    "\033[38;5;111m",  // Sky Blue (Lighter Blue)
+    "\033[38;5;69m",   // Teal/Light Blue
+    "\033[38;5;33m",   // Dark Blue
+    "\033[38;5;201m",  // Magenta
+    "\033[38;5;207m",  // Light Magenta
+	
+};
+
+int line_count = 0;
+
+int
+read_line_count()
+{
+	int fd, line_count = 0;
+	fd = open("/tmp/line_count", O_RDONLY);
+	if (fd >= 0) {
+		read(fd, &line_count, sizeof(line_count));
+		close(fd);
+	}
+	return line_count;
+}
+
+void
+save_line_count(int line_count)
+{
+	int fd = open("/tmp/line_count", O_WRONLY | O_CREATE);
+	write(fd, &line_count, sizeof(line_count));
+	close(fd);
+}
+
+int
+is_psh_enabled()
+{
+	int fd;
+	char buf[2];
+
+	fd = open("/tmp/psh_toggle", O_RDONLY);
+
+	if (fd < 0) {
+		return 0;
+	}
+
+	read(fd, buf, 1);
+	buf[1] = '\0';
+
+	close(fd);
+
+	return (buf[0] == '1') ? 1 : 0;
+}
+
+void
+reset_color()
+{
+	printf("\033[0m");
+}
+
+void
+set_next_color()
+{
+
+	if (is_psh_enabled()) {
+		int line_count = read_line_count();
+		printf("%s", colors_256[line_count % (sizeof(colors_256) / sizeof(colors_256[0]) - 1)]);
+		line_count++;
+		save_line_count(line_count);
+	} else {
+		reset_color();
+	}
+}
+
+
+
+
+
 // Execute cmd.  Never returns.
 void
 runcmd(struct cmd *cmd)
@@ -68,6 +156,13 @@ runcmd(struct cmd *cmd)
   if(cmd == 0)
     exit(1);
 
+  if (is_psh_enabled()) {
+  	set_next_color(); //psh
+  } else {
+  	reset_color();
+  }
+
+
   switch(cmd->type){
   default:
     panic("runcmd");
@@ -76,8 +171,11 @@ runcmd(struct cmd *cmd)
     ecmd = (struct execcmd*)cmd;
     if(ecmd->argv[0] == 0)
       exit(1);
+
+        
     exec(ecmd->argv[0], ecmd->argv);
     fprintf(2, "exec %s failed\n", ecmd->argv[0]);
+
     break;
 
   case REDIR:
@@ -160,10 +258,21 @@ main(void)
   while(getcmd(buf, sizeof(buf)) >= 0){
     if(buf[0] == 'c' && buf[1] == 'd' && buf[2] == ' '){
       // Chdir must be called by the parent, not the child.
-      buf[strlen(buf)-1] = 0;  // chop \n
-      if(chdir(buf+3) < 0)
-        fprintf(2, "cannot cd %s\n", buf+3);
+
+      int len = strlen(buf);
+
+      if (len > 0 && buf[len - 1] == '\n')
+         buf[len - 1] = 0;
+
+      if (chdir(buf + 3) < 0)
+      	fprintf(2, "cannot cd %s\n", buf + 3);
+      
       continue;
+      // 
+      // buf[strlen(buf)-1] = 0;  // chop \n
+      // if(chdir(buf+3) < 0)
+      //   fprintf(2, "cannot cd %s\n", buf+3);
+      // continue;
     }
     if(fork1() == 0)
       runcmd(parsecmd(buf));


### PR DESCRIPTION
Modifications:
 - init.c:
   - creates a directory `/tmp`to store files necessary for `psh`
- created `psh.c`
  - toggles `psh` via file `/tmp/psh_toggle`
- created `pv.c`
  - allows data to be piped in and displays total time to pass through pipe
  - example usage: `cat README.md | pv > new-README.md`
- sh.c:
  - added ANSI codes, logic and functions for `psh`
  - modified `cd` behavior to properly handle certain cases where final char is cut off
 
Limitations:
- `pv` does not show a progress bar
- `psh` requires 256-color support to work properly (this is supported by essentially every modern terminal, so it is functionally a non-issue)
  

(This work was done by Andrew Moore (me) and Athene Marston (aemarston))