### PR TITLE
Add -R, -F, and -v flags to grep

### DIFF
--- a/docs/grep.md
+++ b/docs/grep.md
@@ -1,0 +1,70 @@
+# grep
+
+## NAME
+
+grep - print lines that match patterns
+
+## SYNOPSIS
+
+```
+grep [-R] [-F] [-v] _pattern_ [file...]
+```
+
+## DESCRIPTION
+
+`grep` searches for the specified pattern in each file. If no file is provided,
+`grep` matches against standard input. Patterns are a limited regular
+expression, using `^` for the beginning of a line, `$` for the end of a line,
+`.` to denote any character, and `\*` for Kleene stars.
+
+If `-R` or multiple files are specified, then the path name is printed in red
+before the matching line.
+
+## OPTIONS
+
+`-R`	Read all files under each directory recursively.
+
+`-F`	Use a fixed string as the pattern rather than a regular expression. Can
+	yield slight performance boost.
+
+`-v`	Invert the matching, printing only the lines that _don't_ match
+
+Any other flag will fail.
+
+## EXIT STATUS
+
+`grep` exits with 0 if at least one line matched (or didn't with `-v`), 1 if no
+lines match (or all with `-v`), and 2 if an error occured.
+
+## BUGS/CONSIDERATIONS
+
+* Flags _must_ be specified before the pattern, and must be specified
+  individually.
+* 2 is returned if _any_ error occurs, even if there is a match. Generally a
+  problem when matching against multiple files, and one matches while another
+  errors.
+* Running `grep -R _pattern_` is **not** equivalent to `grep -R _pattern_ .`,
+  instead being equivalent to `grep _pattern_`. This is a bug.
+* Recursion is depth-first, and is ordered by inode creation time rather than
+  lexically.
+* Breaks up lines longer than 1024 characters. Shouldn't affect most people.
+
+## EXAMPLES
+
+`$ grep -R pattern dir`
+
+matches `pattern` against all files in `dir` and its subdirectories (that can
+be opened).
+
+`$ grep -F F.g README.md`
+
+matches README.md against the fixed string `F.g`. The pattern is not
+interpreted as a regular expression, so `Fog` does not match.
+
+`$ grep -v Fog README.md`
+
+matches README.md and prints the lines that _don't_ match the pattern `Fog`.
+
+`$ ls | grep README`
+
+finds a file in the current directory whose name matches the pattern `README`

--- a/user/grep.c
+++ b/user/grep.c
@@ -13,8 +13,10 @@ uint8 Fflag = 0;
 uint8 Rflag = 0;
 uint8 vflag = 0;
 
+uint8 printPath = 0;
+
 void
-grep(char *pattern, int fd)
+grep(char *pattern, int fd, char *path)
 {
   int n, m;
   char *p, *q;
@@ -32,6 +34,8 @@ grep(char *pattern, int fd)
        * Simple xor operation */
       if (match(pattern, p) != vflag) {
         *q = '\n';
+	if (printPath)
+	  fprintf(1, "\x1b[31m%s:\x1b[0m", path);
         write(1, p, q+1 - p);
       }
       p = q+1;
@@ -77,16 +81,18 @@ main(int argc, char *argv[])
       break;
     }
   }
-  /* Mostly so I don't get unused variable errors*/
-  if (Rflag){
-	  fprintf(1, "Flag found\n");
-  }
 
   pattern = argv[i++];
 
   if(argc <= i){
-    grep(pattern, 0);
+    printPath = 0;
+    grep(pattern, 0, "\0");
     exit(0);
+  }
+
+  // Print path if recursion is used or if multiple files are passed
+  if(Rflag || i + 1 < argc) {
+    printPath = 1;
   }
 
   while(i < argc){
@@ -94,7 +100,7 @@ main(int argc, char *argv[])
       printf("grep: cannot open %s\n", argv[i]);
       exit(1);
     }
-    grep(pattern, fd);
+    grep(pattern, fd, argv[i]);
     close(fd);
     i++;
   }

--- a/user/grep.c
+++ b/user/grep.c
@@ -132,7 +132,7 @@ dirgrep(char *pattern, int fd, char *path) {
       grep(pattern, fd, path);
       break;
     case T_DIR:
-      char buf[1024], *p;
+      char buf[128], *p;
       struct dirent de;
       int child_fd;
 


### PR DESCRIPTION
For Issue #54

## Overview
This pull request adds the `-R`, `-F`, and `-v` flags to `grep`, which matches against files in a directory recursively, matches against fixed strings, and inverts matching respectively. A limitation is that the flags must be specified before the pattern or paths, and they must be specified separately.

Additionally, if the `-R` flag is passed or if multiple paths are specified, matches will be printed with the path prefixed in red.

## Examples
- `grep -R pattern dir` matches `pattern` against _all_ files in `dir` and its subdirectories (that can be opened).
- `grep -F F.g README.md` matches README.md against the _fixed_ string `F.g`. The pattern is not interpreted as a regular expression, so `Fog` does not match.
- `grep -v Fog README.md` matches README.md and prints the lines that _don't_ match the pattern `Fog`.

## Files changed
- `user/grep.c`