### PR TITLE
uniq Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ UPROGS=\
 	$U/_mkdir\
 	$U/_rm\
 	$U/_sh\
+	$U/_sort\
 	$U/_stressfs\
 	$U/_uniq\
 	$U/_usertests\

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ UPROGS=\
 	$U/_rm\
 	$U/_sh\
 	$U/_sort\
+	$U/_split\
 	$U/_stressfs\
 	$U/_uniq\
 	$U/_usertests\

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $U/usys.o : $U/usys.S
 $U/_forktest: $U/forktest.o $(ULIB)
 	# forktest has less library code linked in - needs to be small
 	# in order to be able to max out the proc table.
-	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/ulib.o $U/usys.o $U/umalloc.o $U/printf.o
+	$(LD) $(LDFLAGS) -N -e main -Ttext 0 -o $U/_forktest $U/forktest.o $U/printf.o $U/umalloc.o $U/ulib.o $U/usys.o
 	$(OBJDUMP) -S $U/_forktest > $U/forktest.asm
 
 mkfs/mkfs: mkfs/mkfs.c $K/fs.h $K/param.h
@@ -128,6 +128,7 @@ UPROGS=\
 	$U/_rm\
 	$U/_sh\
 	$U/_stressfs\
+	$U/_uniq\
 	$U/_usertests\
 	$U/_grind\
 	$U/_wc\

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ here we go again
 here we go again
 lets test some more
 test command
-
 Voilà! 
 In view, a humble vaudevillian veteran cast vicariously as both victim and villain by the vicissitudes of Fate.
 This visage, no mere veneer of vanity, is a vestige of the vox populi, now vacant, vanished. 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Does this break the code?
 here we go again
 here we go again
 lets test some more
+test command

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# FogOS
-
-![FogOS](docs/fogos.gif)
-
+testing command
+testing this line
+testing this slightly different line
+here we go again
+here we go again
+what are we testing this time?
+Does this break the code?
+	Does this break the code
+here we go agian
+vaudevillian

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ testing this line
 testing this slightly different line
 here we go again
 here we go again
-what are we testing this time?
+what are we testing this time
 Does this break the code?
-	Does this break the code
-here we go agian
-vaudevillian
+        vaudevillian
+here we go again

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ here we go again
 HERE WE GO AGAIN
 lets test some more
 TEST COMMAND
-Voilà! 
+TEST COMMAND
+Voilà!
+
 In view, a humble vaudevillian veteran cast vicariously as both victim and villain by the vicissitudes of Fate.
 This visage, no mere veneer of vanity, is a vestige of the vox populi, now vacant, vanished. 
 However, this valorous visitation of a bygone vexation stands vivified and has vowed to vanquish these venal and virulent vermin vanguarding vice and vouchsafing the violently vicious and voracious violation of volition! 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-testing command
+test command
 testing this line
-testing this slightly different line
+test this slightly different line
 here we go again
 here we go again
-what are we testing this time
+what are testing this time?
 Does this break the code?
-        vaudevillian
+	vaudevillian
 here we go again
+here we go again
+lets test some more

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ here we go again
 here we go again
 lets test some more
 test command
+
+Voilà! 
+In view, a humble vaudevillian veteran cast vicariously as both victim and villain by the vicissitudes of Fate.
+This visage, no mere veneer of vanity, is a vestige of the vox populi, now vacant, vanished. 
+However, this valorous visitation of a bygone vexation stands vivified and has vowed to vanquish these venal and virulent vermin vanguarding vice and vouchsafing the violently vicious and voracious violation of volition! 
+The only verdict is vengeance; a vendetta held as a votive, not in vain, for the value and veracity of such shall one day vindicate the vigilant and the virtuous. 
+Verily, this vichyssoise of verbiage veers most verbose, so let me simply add that it’s my very good honor to meet you and you may call me “V”.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ what are testing this time?
 Does this break the code?
 	vaudevillian
 here we go again
-here we go again
+HERE WE GO AGAIN
 lets test some more
-test command
+TEST COMMAND
 Voilà! 
 In view, a humble vaudevillian veteran cast vicariously as both victim and villain by the vicissitudes of Fate.
 This visage, no mere veneer of vanity, is a vestige of the vox populi, now vacant, vanished. 

--- a/docs/uniq.md
+++ b/docs/uniq.md
@@ -9,8 +9,8 @@ Reports or delets repeated lines in a file.
 ### Description
 The `uniq` command removes consecutive duplicate lines from a file. It reads input
 from either standard input or a specified file and compares adjacent lines to eliminate
-repeated occurrences. Because only adjacent duplicate lines are removed it is sypically
-used in conjusction with the `sort` command to ensure all duplicates are adjacent. The
+repeated occurrences. Because only adjacent duplicate lines are removed it is typically
+used in conjunction with the `sort` command to ensure all duplicates are adjacent. The
 unique lines are then written to standard output.
 
 ### Flags

--- a/docs/uniq.md
+++ b/docs/uniq.md
@@ -1,0 +1,33 @@
+##uniq Command
+
+###Pupose
+Reports or delets repeated lines in a file.
+
+###Syntax
+**uniq** <filename> [-c | -t | -f]
+
+###Description
+The **uniq** command removes consecutive duplicate lines from a file. It reads input
+from either standard input or a specified file and compares adjacent lines to eliminate
+repeated occurrences. Because only adjacent duplicate lines are removed it is sypically
+used in conjusction with the **sort** command to ensure all duplicates are adjacent. The
+unique lines are then written to standard output.
+
+###Flags
+-**-c** prints the count of the unique lines
+-**-t** output the total number of unique lines or words at the end
+-**-f** allows the user to ignore case (case-insensitive comparison for uniqueness)
+
+###Example
+To remove repeated adjacent lines, enter:
+`uniq README.md`
+
+To remove nonadjacent repeated lines, enter:
+`sort README.md | uniq` 
+
+To remove nonadjacent repeated words, enter:
+`split README.md | sort | uniq`
+
+###Bugs
+-The **-f** currently does not produce intended output on nonadjacent words.
+-If the file being processed includes any empty lines the **uniq** command will break.

--- a/docs/uniq.md
+++ b/docs/uniq.md
@@ -1,24 +1,24 @@
-##uniq Command
+## uniq Command
 
-###Pupose
+### Pupose
 Reports or delets repeated lines in a file.
 
-###Syntax
-**uniq** <filename> [-c | -t | -f]
+### Syntax
+`uniq [-c | -t | -f]`
 
-###Description
-The **uniq** command removes consecutive duplicate lines from a file. It reads input
+### Description
+The `uniq` command removes consecutive duplicate lines from a file. It reads input
 from either standard input or a specified file and compares adjacent lines to eliminate
 repeated occurrences. Because only adjacent duplicate lines are removed it is sypically
-used in conjusction with the **sort** command to ensure all duplicates are adjacent. The
+used in conjusction with the `sort` command to ensure all duplicates are adjacent. The
 unique lines are then written to standard output.
 
-###Flags
--**-c** prints the count of the unique lines
--**-t** output the total number of unique lines or words at the end
--**-f** allows the user to ignore case (case-insensitive comparison for uniqueness)
+### Flags
+- **-c**: prints the count of the unique lines
+- **-t**: output the total number of unique lines or words at the end
+- **-f**: allows the user to ignore case (case-insensitive comparison for uniqueness)
 
-###Example
+### Example
 To remove repeated adjacent lines, enter:
 `uniq README.md`
 
@@ -28,6 +28,6 @@ To remove nonadjacent repeated lines, enter:
 To remove nonadjacent repeated words, enter:
 `split README.md | sort | uniq`
 
-###Bugs
--The **-f** currently does not produce intended output on nonadjacent words.
--If the file being processed includes any empty lines the **uniq** command will break.
+### Bugs
+- The **-f** currently does not produce intended output on nonadjacent words.
+- If the file being processed includes any empty lines the `uniq` command will break.

--- a/user/sort.c
+++ b/user/sort.c
@@ -7,18 +7,21 @@
 int
 main(int argc, char *argv[])
 {
-  if (argc < 2) {
-  	printf("usage: sort <filename> [-l | -w]\n");
+  int fd;
+  
+  if (argc == 1) {
+  	fd = 0;
+  } else if (argc >= 2) {
+      char * file_name = argv[1];
+      fd = open(file_name, O_RDONLY);
+      if (fd < 0) {
+        printf("cannot open %s\n", file_name);
+        return -1;
+      }
+  } else {
   	return -1;
   }
 
-  char *file_name = argv[1];
-
-  int fd = open(file_name, O_RDONLY);
-  if (fd < 0) {
-  	printf("cannot open %s\n", file_name);
-  	return -1;
-  }
 
   /*
   * Currently the second and third args of sort are 
@@ -26,10 +29,11 @@ main(int argc, char *argv[])
   */
   if (sort(fd, 0, NULL) != 0) {
   	printf("sort failed\n");
-  	close(fd);
+  	if (fd != 0) close(fd);
   	return 1;
   }
 
+  if (fd != 0) close(fd);
   return 0;
 }
 

--- a/user/sort.c
+++ b/user/sort.c
@@ -1,0 +1,45 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+//#include "user/sortfuncs.h"
+#include <stddef.h>
+
+int
+main(int argc, char *argv[])
+{
+  if (argc != 2) {
+  	printf("Usage: sort <filename>\n");
+  	return -1;
+  }
+
+  char *file_name = argv[1];
+
+  int fd = open(file_name, O_RDONLY);
+  if (fd < 0) {
+  	printf("sort: cannot open %s\n", file_name);
+  	return -1;
+  }
+
+  /*
+  * Currently the second and third args of sort are 
+  * meant for flags, but we are ommiting those for now.
+  */
+  if (sort(fd, 0, NULL) != 0) {
+  	printf("sort failed\n");
+  	close(fd);
+  	return 1;
+  }
+
+  return 0;
+}
+
+
+/*
+* Add sort functions or extend modularity.
+*/
+int
+sort(int fd, int num_flags, char *flags[])
+{
+	return 0;
+}

--- a/user/sort.c
+++ b/user/sort.c
@@ -2,14 +2,13 @@
 #include "kernel/stat.h"
 #include "user/user.h"
 #include "kernel/fcntl.h"
-//#include "user/sortfuncs.h"
 #include <stddef.h>
 
 int
 main(int argc, char *argv[])
 {
-  if (argc != 2) {
-  	printf("Usage: sort <filename>\n");
+  if (argc < 2) {
+  	printf("usage: sort <filename> [-l | -w]\n");
   	return -1;
   }
 
@@ -17,7 +16,7 @@ main(int argc, char *argv[])
 
   int fd = open(file_name, O_RDONLY);
   if (fd < 0) {
-  	printf("sort: cannot open %s\n", file_name);
+  	printf("cannot open %s\n", file_name);
   	return -1;
   }
 
@@ -35,11 +34,95 @@ main(int argc, char *argv[])
 }
 
 
-/*
-* Add sort functions or extend modularity.
-*/
-int
-sort(int fd, int num_flags, char *flags[])
+void
+free_lines(int num_lines, char *lines[])
 {
-	return 0;
+  for (int i = 0; i < num_lines; i++) {
+    free(*(lines + i));
+  }
+  free(lines);
+  lines = NULL;
+}
+
+void
+print_lines(int num_lines, char *lines[])
+{
+  for (int i = 0; i < num_lines; i++) {
+  	printf("%s", *(lines + i));
+  }
+}
+
+void
+insertion_sort_line(int num_lines, char *lines[])
+{
+  for (int i = 1; i < num_lines; i++) {
+  	char *curr_line = lines[i];
+  	int j = i - 1;
+
+  	while (j >= 0 && strcmp(lines[j], curr_line) > 0) {
+  	  lines[j + 1] = lines[j];
+  	  j--;
+  	}
+
+  	lines[j + 1] = curr_line;
+  }
+}
+
+
+int 
+sort(int fd, int num_flags, char *flags[]) 
+{
+  uint sz = 128;
+  int count = 0; 
+  uint buf = 0;  
+  char **lines = 0;
+
+ 
+  while (1) {
+    
+    if (count >= buf) {
+      uint new_buf;
+      if (buf == 0) {
+        new_buf = 8;
+      } else {
+        new_buf = buf * 2;
+      }
+
+      char **new_lines = (char **)malloc(new_buf * sizeof(char *));
+      if (new_lines == NULL) {
+        printf("malloc failed\n");
+        return 1;
+      }
+
+      if (lines) {
+        for (int i = 0; i < count; i++) {
+          new_lines[i] = lines[i];
+        }
+        free(lines);
+      }
+
+      lines = new_lines;
+      buf = new_buf;
+    }
+
+    char *line = malloc(sz);
+    if (line == NULL) {
+      printf("malloc failed\n");
+      return 1;
+    }
+    
+    if (getline(&line, &sz, fd) <= 0) {
+      free(line);
+      break;
+    }
+
+    lines[count] = line;
+    count++;
+  }
+    
+    insertion_sort_line(count, lines);
+    print_lines(count, lines);
+    free_lines(count, lines);
+
+    return 0;
 }

--- a/user/sort.c
+++ b/user/sort.c
@@ -23,10 +23,10 @@ main(int argc, char *argv[])
   }
 
 
-  /*
-  * Currently the second and third args of sort are 
-  * meant for flags, but we are ommiting those for now.
-  */
+  /**
+   * Currently the second and third args of sort are 
+   * meant for flags, but we are ommiting those for now.
+   */
   if (sort(fd, 0, NULL) != 0) {
   	printf("sort failed\n");
   	if (fd != 0) close(fd);
@@ -38,6 +38,12 @@ main(int argc, char *argv[])
 }
 
 
+/**
+ * frees the memory allocated for an array of strings
+ * 
+ * @param num_lines number of lines in the array
+ * @param lines array of strings to be freed
+ */
 void
 free_lines(int num_lines, char *lines[])
 {
@@ -48,6 +54,13 @@ free_lines(int num_lines, char *lines[])
   lines = NULL;
 }
 
+
+/**
+ * prints an array of strings
+ * 
+ * @param num_lines number of lines in the array
+ * @param lines array of strings to be printed
+*/
 void
 print_lines(int num_lines, char *lines[])
 {
@@ -56,6 +69,13 @@ print_lines(int num_lines, char *lines[])
   }
 }
 
+
+/**
+ * sorts an array of strings using insertion sort
+ * 
+ * @param num_lines number of lines in the array
+ * @param lines array of strings to be sorted
+ */
 void
 insertion_sort_line(int num_lines, char *lines[])
 {
@@ -73,6 +93,14 @@ insertion_sort_line(int num_lines, char *lines[])
 }
 
 
+/**
+ * reads lines from a file, sorts them, and prints them
+ * 
+ * @param fd file descriptor of the file to be sorted
+ * @param num_flags number of flags (currently unused)
+ * @param flags array of flags (currently unused)
+ * @return int returns 0 on success, 1 on failure
+ */
 int 
 sort(int fd, int num_flags, char *flags[]) 
 {

--- a/user/sort.c
+++ b/user/sort.c
@@ -4,41 +4,8 @@
 #include "kernel/fcntl.h"
 #include <stddef.h>
 
-int
-main(int argc, char *argv[])
-{
-  int fd;
-  
-  if (argc == 1) {
-  	fd = 0;
-  } else if (argc >= 2) {
-      char * file_name = argv[1];
-      fd = open(file_name, O_RDONLY);
-      if (fd < 0) {
-        printf("cannot open %s\n", file_name);
-        return -1;
-      }
-  } else {
-  	return -1;
-  }
 
-
-  /**
-   * Currently the second and third args of sort are 
-   * meant for flags, but we are ommiting those for now.
-   */
-  if (sort(fd, 0, NULL) != 0) {
-  	printf("sort failed\n");
-  	if (fd != 0) close(fd);
-  	return 1;
-  }
-
-  if (fd != 0) close(fd);
-  return 0;
-}
-
-
-/**
+/*
  * frees the memory allocated for an array of strings
  * 
  * @param num_lines number of lines in the array
@@ -55,12 +22,12 @@ free_lines(int num_lines, char *lines[])
 }
 
 
-/**
+/*
  * prints an array of strings
  * 
  * @param num_lines number of lines in the array
  * @param lines array of strings to be printed
-*/
+ */
 void
 print_lines(int num_lines, char *lines[])
 {
@@ -70,7 +37,7 @@ print_lines(int num_lines, char *lines[])
 }
 
 
-/**
+/*
  * sorts an array of strings using insertion sort
  * 
  * @param num_lines number of lines in the array
@@ -93,7 +60,7 @@ insertion_sort_line(int num_lines, char *lines[])
 }
 
 
-/**
+/*
  * reads lines from a file, sorts them, and prints them
  * 
  * @param fd file descriptor of the file to be sorted
@@ -102,7 +69,7 @@ insertion_sort_line(int num_lines, char *lines[])
  * @return int returns 0 on success, 1 on failure
  */
 int 
-sort(int fd, int num_flags, char *flags[]) 
+sort(int fd) 
 {
   uint sz = 128;
   int count = 0; 
@@ -157,4 +124,33 @@ sort(int fd, int num_flags, char *flags[])
     free_lines(count, lines);
 
     return 0;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  int fd;
+  
+  if (argc == 1) {
+  	fd = 0;
+  } else if (argc >= 2) {
+      char * file_name = argv[1];
+      fd = open(file_name, O_RDONLY);
+      if (fd < 0) {
+        printf("cannot open %s\n", file_name);
+        return -1;
+      }
+  } else {
+  	return -1;
+  }
+
+  if (sort(fd) != 0) {
+  	printf("sort failed\n");
+  	if (fd != 0) close(fd);
+  	return 1;
+  }
+
+  if (fd != 0) close(fd);
+  return 0;
 }

--- a/user/split.c
+++ b/user/split.c
@@ -57,7 +57,7 @@ split(int fd, uint sz)
       	  if (word_index >= word_sz - 1) {
       	  	int new_sz = word_sz * 2;
       	  	char *new_word = malloc(new_sz);
-      	  	if (new_word) {
+      	  	if (new_word == NULL) {
       	  	  printf("malloc failed\n");
       	  	  free(word);
       	  	  return;

--- a/user/split.c
+++ b/user/split.c
@@ -79,10 +79,10 @@ split(int fd, uint sz)
     }
   }
   
-  if (word_index > 0) {
-    word[word_index] = '\0';
-    printf("%s\n", word);
-  }
+  // if (word_index > 0) {
+  //   word[word_index] = '\0';
+  //   printf("%s\n", word);
+  // }
 
   free(word);
 }

--- a/user/split.c
+++ b/user/split.c
@@ -1,0 +1,81 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+#include <stddef.h>
+
+int
+main(int argc, char *argv[])
+{
+  if ( argc < 2) {
+  	printf("usage: split <filename>\n");
+  	return -1;
+  }
+
+  char *file_name = argv[1];
+
+  int fd = open(file_name, O_RDONLY);
+  if (fd < 0) {
+    printf("cannot open %s\n", file_name);
+    return -1;
+  }
+  
+  uint sz = 128;
+  split(fd, sz);
+
+  close(fd);
+  return 0;
+}
+
+void
+split(int fd, uint sz)
+{
+  char buffer[sz];
+  int chars_read;
+  uint word_sz = sz;
+  char *word = malloc(word_sz);
+  int word_index = 0;
+
+  if(word == NULL) {
+    printf("malloc failed\n");
+    exit(1);
+  }
+
+  while ((chars_read = read(fd, buffer, sz)) > 0) {
+    for (int i = 0; i < chars_read; ++i) {
+      char c = buffer[i];
+
+      if (c == ' ' || c == '\n' || c == '\t') {
+      	if (word_index > 0) {
+      	  word[word_index] = '\0';
+      	  printf("%s\n", word);
+      	  word_index = 0;
+      	}
+      } else {
+      	  word[word_index++] = c;
+
+      	  if (word_index >= word_sz - 1) {
+      	  	int new_sz = word_sz * 2;
+      	  	char *new_word = malloc(new_sz);
+      	  	if (new_word) {
+      	  	  printf("malloc failed\n");
+      	  	  free(word);
+      	  	  return;
+      	  	}
+
+      	  	memcpy(new_word, word, word_sz);
+      	  	free(word);
+      	  	word = new_word;
+      	  	word_sz = new_sz;
+      	  }
+      }
+    }
+  }
+  
+  if (word_index > 0) {
+    word[word_index] = '\0';
+    printf("%s\n", word);
+  }
+
+  free(word);
+}

--- a/user/split.c
+++ b/user/split.c
@@ -4,36 +4,14 @@
 #include "kernel/fcntl.h"
 #include <stddef.h>
 
-int
-main(int argc, char *argv[])
-{
-  int fd;
-  
-  if ( argc < 2) {
-    fd = 0;
-  } else {
-  	char *file_name = argv[1];
-  	fd = open(file_name, O_RDONLY);
-  	if (fd < 0) {
-  	  printf("cannot open %s\n", file_name);
-  	  return -1;
-  	}
-  }
-  
-  uint sz = 128;
-  split(fd, sz);
-
-  close(fd);
-  return 0;
-}
-
 
 /*
-* splits the content of a file into words and prints them
-* 
-* @param fd File Descriptor of the file to be split
-* @param sz buffer size to reallocate later
-*/
+ * Reads file per character, builing words until delimiter is
+ * found. Reallocates buffer if word is greater than size.
+ * 
+ * @param fd File Descriptor of the file to be split
+ * @param sz buffer size to reallocate later
+ */
 void
 split(int fd, uint sz)
 {
@@ -78,11 +56,30 @@ split(int fd, uint sz)
       }
     }
   }
-  
-  // if (word_index > 0) {
-  //   word[word_index] = '\0';
-  //   printf("%s\n", word);
-  // }
 
   free(word);
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  int fd;
+  
+  if ( argc < 2) {
+    fd = 0;
+  } else {
+  	char *file_name = argv[1];
+  	fd = open(file_name, O_RDONLY);
+  	if (fd < 0) {
+  	  printf("cannot open %s\n", file_name);
+  	  return -1;
+  	}
+  }
+  
+  uint sz = 128;
+  split(fd, sz);
+
+  close(fd);
+  return 0;
 }

--- a/user/split.c
+++ b/user/split.c
@@ -7,17 +7,17 @@
 int
 main(int argc, char *argv[])
 {
+  int fd;
+  
   if ( argc < 2) {
-  	printf("usage: split <filename>\n");
-  	return -1;
-  }
-
-  char *file_name = argv[1];
-
-  int fd = open(file_name, O_RDONLY);
-  if (fd < 0) {
-    printf("cannot open %s\n", file_name);
-    return -1;
+    fd = 0;
+  } else {
+  	char *file_name = argv[1];
+  	fd = open(file_name, O_RDONLY);
+  	if (fd < 0) {
+  	  printf("cannot open %s\n", file_name);
+  	  return -1;
+  	}
   }
   
   uint sz = 128;
@@ -27,6 +27,13 @@ main(int argc, char *argv[])
   return 0;
 }
 
+
+/*
+* splits the content of a file into words and prints them
+* 
+* @param fd File Descriptor of the file to be split
+* @param sz buffer size to reallocate later
+*/
 void
 split(int fd, uint sz)
 {

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -112,7 +112,12 @@ getline(char **lineptr, uint *n, int fd)
 
     
     if (read_sz == 0) {
+      if (total_read == 0) {
+      	return -1;
+      }
+      buf[total_read] = '\0';
       return total_read;
+
     } else if (read_sz == -1) {
       return -1;
     }
@@ -120,6 +125,7 @@ getline(char **lineptr, uint *n, int fd)
     total_read += read_sz;
     
     if (buf[total_read - 1] == '\n' || buf[total_read - 1] == '\t') {
+      buf[total_read] = '\0';
       return total_read;
     }
 
@@ -129,7 +135,6 @@ getline(char **lineptr, uint *n, int fd)
     free(buf);
 
     buf = new_buf;
-
     *n = new_n;
     *lineptr = buf;
   }

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -96,41 +96,38 @@ fgets(int fd, char *buf, int max)
 }
 
 int
-getline(char **lineptr, uint *n, int fd)
+getline(char **buffer, uint *buffer_size, int file_descriptor)
 {
-  if (*lineptr == 0 && *n == 0) {
-    *n = 128;
-    *lineptr = malloc(*n);
+  int bytes_read = 0;
+  int total_bytes_read = 0;
+  char last_char;
+
+  if (*buffer == NULL || *buffer_size == 0) {
+    *buffer_size = 16;
+    *buffer = (char *) malloc(*buffer_size);
+    if (*buffer == NULL) return -1;
   }
 
-  char *buf = *lineptr;
-  uint total_read = 0;
-  while (1) {
-    int read_sz = fgets(fd, buf + total_read, *n - total_read);
-    if (read_sz == 0) {
-      return total_read;
-    } else if (read_sz == -1) {
-      // error
-      return -1;
-    }
+  bytes_read = fgets(file_descriptor, *buffer, *buffer_size);
+  while (bytes_read > 0) {
+    total_bytes_read += bytes_read;
+    last_char = *(*(buffer) + *buffer_size - 2); // Last readable char -> last char is null byte
+    if (last_char == '\n' || last_char == '\0') return total_bytes_read;
 
-    total_read += read_sz;
-    if (buf[total_read - 1] == '\n' || buf[total_read - 1] == '\t') {
-      return total_read;
-    }
+    /* Double size of buffer */
+    *buffer_size *= 2;
+    char *resized_buffer = (char *) malloc(*buffer_size);
+    if (resized_buffer == NULL) return -1;
 
-    uint new_n = *n * 2;
-    char *new_buf = malloc(new_n);
-    memcpy(new_buf, buf, *n);
-    free(buf);
+    memcpy(resized_buffer, *buffer, total_bytes_read);
+    free(*buffer);
 
-    buf = new_buf;
-
-    *n = new_n;
-    *lineptr = buf;
+    /* Start writing to end of current buffer. Only write to remaining number of bytes in buffer -> prevents buffer overflow */
+    bytes_read = fgets(file_descriptor, resized_buffer + total_bytes_read, *buffer_size - total_bytes_read);
+    *buffer = resized_buffer;
   }
 
-  return total_read;
+  return bytes_read; // Will always be 0 here -> we only get here if while loop condition fails
 }
 
 int

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -89,10 +89,6 @@ fgets(int fd, char *buf, int max)
 	  if (c == '\n' || c == '\r') {
 	  	break;
 	  }
-	  else if (c == '\t') { // we want to remove tabs
-	  	i--;
-	  	break;
-	  }
   }
 
   buf[i] = '\0';

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -95,6 +95,11 @@ fgets(int fd, char *buf, int max)
   return i;
 }
 
+
+/*
+* Function written by Shyon Ghahghahi and Amin Joseph utilized in
+* their sort command.
+*/
 int
 getline(char **buffer, uint *buffer_size, int file_descriptor)
 {

--- a/user/ulib.c
+++ b/user/ulib.c
@@ -98,6 +98,7 @@ fgets(int fd, char *buf, int max)
 int
 getline(char **lineptr, uint *n, int fd)
 {
+
   if (*lineptr == 0 && *n == 0) {
     *n = 128;
     *lineptr = malloc(*n);
@@ -108,6 +109,8 @@ getline(char **lineptr, uint *n, int fd)
   
   while (1) {
     int read_sz = fgets(fd, buf + total_read, *n - total_read);
+
+    
     if (read_sz == 0) {
       return total_read;
     } else if (read_sz == -1) {
@@ -130,7 +133,6 @@ getline(char **lineptr, uint *n, int fd)
     *n = new_n;
     *lineptr = buf;
   }
-
   return total_read;
 }
 

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -227,7 +227,7 @@ main(int argc, char *argv[])
     }
    arg_start = 2;
   }
-  
+
   uniq(&argv[arg_start], fd);
 
   if (fd != 0) {

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -99,7 +99,6 @@ void print_uniq(int count, char *lines[], bool cflag) {
   }
 }
 
-
 /*
 * creates a char * of all the lines from a given file and
 * prints out all the unique lines
@@ -108,51 +107,51 @@ void print_uniq(int count, char *lines[], bool cflag) {
 * @param cflag boolean for the -c flag
 */
 void 
-lines(int fd, bool cflag) {
+lines(int fd, bool cflag) 
+{
   uint sz = 20; // getline will resize if necessary
   int buf = 0;
   int count = 0; // num of lines
   char **lines = 0;
-
+  
   while (1) {
     if (count >= buf) {
-      uint new_buf;
-      if (buf == 0) {
-        new_buf = 8; // small buf to see reallocation
-      } else {
-        new_buf = buf * 2;
-      }
-
-      char **new_lines = malloc(new_buf * sizeof(char *));
-      if (new_lines == 0) {
-        printf("malloc failed");
-      	exit(1);
-      }
-      if (lines) {
-      	for (int i = 0; i < count; i++) {
-      	  new_lines[i] = lines[i];
-      	}
-      	free(lines);
-      }
-      lines = new_lines;
-      buf = new_buf;
+    uint new_buf;
+    if (buf == 0) {
+       new_buf = 8; // small buf to see reallocation
+    } else {
+      new_buf = buf * 2;
     }
 
+    char **new_lines = malloc(new_buf * sizeof(char *));
+    if (new_lines == 0) {
+      printf("malloc failed");
+      exit(1);
+    }
+    if (lines) {
+      for (int i = 0; i < count; i++) {
+        new_lines[i] = lines[i];
+      }
+      free(lines);
+    }
+    lines = new_lines;
+    buf = new_buf;
+    }
+  
     char *line = malloc(sz);
     if (getline(&line, &sz, fd) <= 0) {
       free(line);
       break;
     }
-    
+      
     lines[count] = line;
     count++;
   }
-    bubble_sort(lines, count);
-    print_uniq(count, lines, cflag);
-    
-    for (int i = 0; i < count; i++) {
-      free(lines[i]);
-    }
+  print_uniq(count, lines, cflag);
+      
+  for (int i = 0; i < count; i++) {
+    free(lines[i]);
+  }
 }
 
 /*
@@ -255,7 +254,8 @@ words(int fd, bool cflag) {
 * @param fd file descriptor of file to read
 */
 void
-uniq(char *argv[], int fd) {
+uniq(char *argv[], int fd) 
+{
   int j = 0; 
 
   //FINDING PROPER FLAGS
@@ -280,20 +280,15 @@ uniq(char *argv[], int fd) {
   lines(fd, false);
 }
 
-int main(int argc, char *argv[]){
 
-	if (argc < 2) {
-		printf("usage: uniq filename [-w] [-c] [-wc]\n");
-		return -1;
-	}
-
-  int fd = open(argv[1], O_RDONLY);
-  if (fd < 1) {
-  	printf("err opening file\n");
-  	return -1;
+int main(int argc, char *argv[])
+{
+  if (argc < 1) {
+    printf("usage: uniq filename [-w] [-c] [-wc]\n");
+	return -1;
   }
-  uniq(argv, fd);
-  return 0;
 
+  uniq(argv, 0);
+  return 0;
 }
 

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -7,52 +7,10 @@
 
 
 /*
-* writes a line word by word to a given file
-*
-* @param line to write
-* @param fd file descriptor to write to
-*/
-void *
-writewords(char *line, int fd)
-{
-  bool in_word = false;
-  // first char we check is the start of the line
-  char *character = &line[0];
-  while (*character != '\0') { // while we aren't at the end
-    if (*character == ' ' || *character == '\t') { // if we reach the end of a word
-      if (in_word) {
-        write(fd, "\n", 1);
-      } 
-    } else {
-      write(fd, character, 1);
-      in_word = true;
-    }
-    character++;
-  }
-  if (in_word) {
-  	write(fd, "\n", 1);
-  }
-  return 0;
-}
-
-
-/*
-* frees memory allocated for the lines array
-*
-* @param num_lines max num of lines
-* @param lines array of lines
-*/
-void
-free_lines(int num_lines, char *lines[])
-{
-  for (int i = 0; i < num_lines; i++) {
-    free(*(lines + i));
-  }
-  free(lines);
-  lines = NULL;
-}
-
-
+ * converts an uppercase character to lowercase
+ *
+ * @param c the character to be converted
+ */
 char 
 tolower(char c) 
 {
@@ -63,6 +21,12 @@ tolower(char c)
 }
 
 
+/*
+ * performs a comparison between two strings
+ * 
+ * @param s1 the first string to be compared
+ * @param s2 the second string to be compared
+ */
 int
 strcmp_helper(const char *s1, const char *s2) {
   while (*s1 && *s2) {
@@ -77,134 +41,94 @@ strcmp_helper(const char *s1, const char *s2) {
   return tolower(*s1) - tolower(*s2);
 }
 
-/*
-* prints out the uniq instances from a provided sorted
-* char* array
-*
-* @param count max num of lines or words
-* @param lines array of lines or words
-* @param cflag boolean for the -c flag
-*/
-int 
-print_uniq(int count, char *lines[], bool cflag, bool fflag) 
-{
-  int curr = 0; // keeps track of which line we're at
-  int instances = 1; // keeps track of how many instances
-  int unique_count = 0;
-
-  while(curr < count) { // while we still have stuff to read
-    // skip null terms and line ends
-    if ((strcmp(lines[curr], "\0") == 0) || (strcmp(lines[curr], "\n") == 0)
-            || (strcmp(lines[curr], "\t") == 0)) {
-       continue;
-    }
-
-    bool equal;
-    if (fflag) {
-    	equal = strcmp_helper(lines[curr], lines[curr + 1]) == 0;
-    } else {
-        equal = strcmp(lines[curr], lines[curr + 1]) == 0;
-    }
-
-    if((curr + 1 < count) && equal) {
-      instances++;
-    } else {
-        unique_count++;
-        if (cflag) { // with count
-          printf("%d %s", instances, lines[curr]);
-        } else { // without count
-            printf("%s", lines[curr]);
-        }
-      instances = 1;
-     }
-
-    curr++;
-  }
-  return unique_count;
-}
-
 
 /*
-* creates a char * of all the lines from a given file and
-* prints out all the unique lines
-*
-* @param fd file descriptor of file to read
-* @param cflag boolean for the -c flag
-*/
+ * creates a char * of all the lines from a given file and
+ * prints out all the unique lines
+ *
+ * @param fd file descriptor of file to read
+ * @param cflag boolean for the -c flag
+ */
 void 
 lines(int fd, bool cflag, bool tflag, bool fflag) 
 {
-  uint sz = 20; // getline will resize if necessary
-  int buf = 0;
-  int count = 0; // num of lines
-  char **lines = 0;
-  
-  while (1) {
-    if (count >= buf) {
-    uint new_buf;
-    if (buf == 0) {
-       new_buf = 8; // small buf to see reallocation
-    } else {
-      new_buf = buf * 2;
-    }
+  uint sz = 0;
+  int dupe_count = 1, unique_count = 0;
+  char *last_line = NULL, *line;
 
-    char **new_lines = malloc(new_buf * sizeof(char *));
-    if (new_lines == 0) {
-      printf("malloc failed");
-      exit(1);
-    }
-    if (lines) {
-      for (int i = 0; i < count; i++) {
-        new_lines[i] = lines[i];
-      }
-      free(lines);
-    }
-    lines = new_lines;
-    buf = new_buf;
-    }
-  
-    char *line = malloc(sz);
-    if (getline(&line, &sz, fd) <= 0) {
-      free(line);
-      break;
-    }
-      
-    lines[count] = line;
-    count++;
+  if (getline(&line, &sz, fd) > 0) {
+  		last_line = malloc(strlen(line) + 1);
+  		if (last_line) {
+  			strcpy(last_line, line);
+  		}
+
+  		while (getline(&line, &sz, fd) > 0) {
+  				bool equal;
+
+  				if (fflag) {
+  					equal = strcmp_helper(line, last_line) == 0;
+  				} else {
+  					equal = strcmp(line, last_line) == 0;
+  				}
+  				
+  				if (equal) {
+  					dupe_count++;
+  				} else {
+  					unique_count++;
+  					if (cflag) {
+  						printf("%d %s", dupe_count, last_line);
+  					} else {
+  						printf("%s", last_line);
+  					}
+  					free(last_line);
+  					last_line = malloc(strlen(line) + 1);
+  					if (last_line) {
+  						strcpy(last_line, line);
+  					}
+  					dupe_count = 1;
+  				}
+  		}
+
+  		unique_count++;
+  		if (cflag) {
+  			printf("%d %s", dupe_count, last_line);
+  		} else {
+  			printf("%s", last_line);
+  		}
+
+  		if (tflag) {
+  			printf("Total unique lines/words: %d\n", unique_count);
+  		}
+
+  		free(last_line);
   }
-  int unique_count = print_uniq(count, lines, cflag, fflag);
 
-  if (tflag) {
-  	printf("Total unique lines/words: %d\n", unique_count);
-  }
-
-  free_lines(count, lines);
+  free(line);
 }
 
 
 /*
-* creates a char * of all the lines from a given file and
-* prints out all the unique lines
-*
-* @param argv array of args to check for flags
-* @param fd file descriptor of file to read
-*/
+ * creates a char * of all the lines from a given file and
+ * prints out all the unique lines
+ *
+ * @param argv array of args to check for flags
+ * @param fd file descriptor of file to read
+ */
 void
 uniq(char *argv[], int fd) 
 {
   int j = 0;
   bool cflag = false;
-  bool tflag = false; 
-  bool fflag = false;
+  bool tflag = false;
+  bool fflag = false; 
 
-  //FINDING PROPER FLAGS
   while (argv[j] != NULL) {
     if (!strcmp(argv[j], "-c")) {
       cflag = true;
     } else if (!strcmp(argv[j], "-t")) {
     	tflag = true;
     } else if (!strcmp(argv[j], "-f")) {
-        fflag = true;
+    	fflag = true;
     }
     j++;
   }

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -5,37 +5,37 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-/*
-* helper function for sort that swaps two
-* values from an array
-*
-* @param array to swap in
-* @param i one index to swap
-* @param j other index to swap
-*/
-void
-swap(char * list[], int i, int j) {
-  char * temp = list[i];
-  list[i] = list[j];
-  list[j] = temp;
-}
-
-/*
-* bubble sorts an array of char *
-*
-* @param array to sort
-* @param length of array
-*/
-void
-bubble_sort(char *list[], int length) {
-  for (int i = 0; i < length; i++) {
-    for (int j = i + 1; j < length; j++) {
-      if (strcmp(list[i], list[j]) > 0) {
-        swap(list, i, j);
-      }
-    }
-  }
-}
+// /*
+// * helper function for sort that swaps two
+// * values from an array
+// *
+// * @param array to swap in
+// * @param i one index to swap
+// * @param j other index to swap
+// */
+// void
+// swap(char * list[], int i, int j) {
+//   char * temp = list[i];
+//   list[i] = list[j];
+//   list[j] = temp;
+// }
+// 
+// /*
+// * bubble sorts an array of char *
+// *
+// * @param array to sort
+// * @param length of array
+// */
+// void
+// bubble_sort(char *list[], int length) {
+//   for (int i = 0; i < length; i++) {
+//     for (int j = i + 1; j < length; j++) {
+//       if (strcmp(list[i], list[j]) > 0) {
+//         swap(list, i, j);
+//       }
+//     }
+//   }
+// }
 
 /*
 * writes a line word by word to a given file
@@ -44,7 +44,8 @@ bubble_sort(char *list[], int length) {
 * @param fd file descriptor to write to
 */
 void *
-writewords(char *line, int fd){
+writewords(char *line, int fd)
+{
   // first char we check is the start of the line
   char *character = &line[0];
   while (*character != '\0') { // while we aren't at the end
@@ -69,7 +70,9 @@ writewords(char *line, int fd){
 * @param lines array of lines or words
 * @param cflag boolean for the -c flag
 */
-void print_uniq(int count, char *lines[], bool cflag) {
+void 
+print_uniq(int count, char *lines[], bool cflag) 
+{
   int curr = 0; // keeps track of which line we're at
   int instances = 1; // keeps track of how many instances
 
@@ -154,6 +157,7 @@ lines(int fd, bool cflag)
   }
 }
 
+
 /*
 * creates a char * of all the words from a given file and
 * prints out all the unique words
@@ -162,87 +166,65 @@ lines(int fd, bool cflag)
 * @param cflag boolean for the -c flag
 */
 void 
-words(int fd, bool cflag) {
-  uint sz = 20;  // getline will resize if necessary
-  int count = 0;
-  int buf = 10;  // buffer words array
-  char **words = malloc(buf * sizeof(char *));  //array of words
-
-  if (words == NULL) {
-    printf("malloc failed\n");
-    return;
-  }
-
-  int write = open("/temp.txt", O_CREATE | O_WRONLY);
-  if (write < 0) {
-    printf("Error opening file: temp.txt\n");
-    free(words);
-    return;
-  }
-
-  while (1) {
-    char *line = malloc(sz);
-    if (line == NULL) {
-      printf("malloc failed\n");
-      break;
-    }
-    
-    int result = getline(&line, &sz, fd);
-    if (result <= 0) {
-      free(line);
-      break;
-    }
-
-    writewords(line, write);
-    free(line);
-  }
-  close(write);
-
-  // reading the words back from temp.txt
-  int read = open("/temp.txt", O_RDONLY);
-  if (read < 0) {
-    printf("Error opening file: temp.txt\n");
-    free(words);
-    return;
-  }
-
-  uint newsize = 10;
-  while (1) {
-    char *word = malloc(newsize);
-    if (word == NULL) {
-      printf("mem failed\n");
-      break;
-    }
-
-    int result = getline(&word, &newsize, read);
-    if (result <= 0) {
-      free(word);
-      break;
-    }
-
-    if (count >= buf) {
-      int new_buf = buf * 2;
-      char **new_words = malloc(new_buf * sizeof(char *));
-      if (new_words == NULL) {
-        break;
-      }
-
-      for (int i = 0; i < count; i++) {
-        new_words[i] = words[i];
-      }
-      
-      free(words);
-      words = new_words;
-      buf = new_buf;
-    }
-    words[count] = word;
-    count++;
-  }
-
-  close(read);
-
-  bubble_sort(words, count);
-  print_uniq(count, words, cflag);
+words(int fd, bool cflag) 
+{
+//   uint sz = 20;  // getline will resize if necessary
+//   int count = 0;
+//   int buf = 10;  // buffer words array
+//   char **words = malloc(buf * sizeof(char *));  //array of words
+// 
+//   if (words == NULL) {
+//     printf("malloc failed\n");
+//     return;
+//   }
+//   
+//   char *prev_word = NULL;
+// 
+//   while (1) {
+//     char *word = malloc(sz);
+//     if (word == NULL) {
+//       printf("malloc failed\n");
+//       break;
+//     }
+//     
+//     int result = getline(&word, &sz, fd);
+//     if (result <= 0) {
+//       free(word);
+//       break;
+//     }
+// 
+//     if (prev_word != NULL && strcmp(prev_word, word) == 0) {
+//       free(word);
+//       continue;
+//     }
+// 
+//     if (count >= buf) {
+//       int new_buf = buf * 2;
+//       char **new_words = malloc(new_buf * sizeof(char *));
+//       if (new_words == NULL) {
+//         printf("malloc failed\n");
+//         break;
+//       }
+// 
+//       for (int i = 0; i < count; i++) {
+//       	new_words[i] = words[i];
+//       }
+// 
+//       free(words);
+//       words = new_words;
+//       buf = new_buf;
+//     }
+//     words[count] = word;
+//     count++;
+//     prev_word = word;
+//   }
+// 
+//   print_uniq(count, words, cflag);
+// 
+//   for (int i = 0; i < count; i++) {
+//   	free(words[i]);
+//   }
+//   free(words);
 }
 
 

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -167,7 +167,8 @@ uniq(char *argv[], int fd)
 }
 
 
-int main(int argc, char *argv[])
+int 
+main(int argc, char *argv[])
 {
   int fd = 0;
   int arg_start = 1;

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -5,37 +5,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// /*
-// * helper function for sort that swaps two
-// * values from an array
-// *
-// * @param array to swap in
-// * @param i one index to swap
-// * @param j other index to swap
-// */
-// void
-// swap(char * list[], int i, int j) {
-//   char * temp = list[i];
-//   list[i] = list[j];
-//   list[j] = temp;
-// }
-// 
-// /*
-// * bubble sorts an array of char *
-// *
-// * @param array to sort
-// * @param length of array
-// */
-// void
-// bubble_sort(char *list[], int length) {
-//   for (int i = 0; i < length; i++) {
-//     for (int j = i + 1; j < length; j++) {
-//       if (strcmp(list[i], list[j]) > 0) {
-//         swap(list, i, j);
-//       }
-//     }
-//   }
-// }
 
 /*
 * writes a line word by word to a given file
@@ -66,6 +35,24 @@ writewords(char *line, int fd)
 * prints out the uniq instances from a provided sorted
 * char* array
 *
+* @param num_lines max num of lines
+* @param lines array of lines
+*/
+void
+free_lines(int num_lines, char *lines[])
+{
+  for (int i = 0; i < num_lines; i++) {
+    free(*(lines + i));
+  }
+  free(lines);
+  lines = NULL;
+}
+
+
+/*
+* prints out the uniq instances from a provided sorted
+* char* array
+*
 * @param count max num of lines or words
 * @param lines array of lines or words
 * @param cflag boolean for the -c flag
@@ -80,7 +67,6 @@ print_uniq(int count, char *lines[], bool cflag)
     // skip null terms and line ends
     if ((strcmp(lines[curr], "\0") == 0) || (strcmp(lines[curr], "\n") == 0)
             || (strcmp(lines[curr], "\t") == 0)) {
-       //curr++;
        continue;
     }
 
@@ -101,6 +87,7 @@ print_uniq(int count, char *lines[], bool cflag)
     curr++;
   }
 }
+
 
 /*
 * creates a char * of all the lines from a given file and
@@ -159,76 +146,6 @@ lines(int fd, bool cflag)
 
 
 /*
-* creates a char * of all the words from a given file and
-* prints out all the unique words
-*
-* @param fd file descriptor of file to read
-* @param cflag boolean for the -c flag
-*/
-void 
-words(int fd, bool cflag) 
-{
-//   uint sz = 20;  // getline will resize if necessary
-//   int count = 0;
-//   int buf = 10;  // buffer words array
-//   char **words = malloc(buf * sizeof(char *));  //array of words
-// 
-//   if (words == NULL) {
-//     printf("malloc failed\n");
-//     return;
-//   }
-//   
-//   char *prev_word = NULL;
-// 
-//   while (1) {
-//     char *word = malloc(sz);
-//     if (word == NULL) {
-//       printf("malloc failed\n");
-//       break;
-//     }
-//     
-//     int result = getline(&word, &sz, fd);
-//     if (result <= 0) {
-//       free(word);
-//       break;
-//     }
-// 
-//     if (prev_word != NULL && strcmp(prev_word, word) == 0) {
-//       free(word);
-//       continue;
-//     }
-// 
-//     if (count >= buf) {
-//       int new_buf = buf * 2;
-//       char **new_words = malloc(new_buf * sizeof(char *));
-//       if (new_words == NULL) {
-//         printf("malloc failed\n");
-//         break;
-//       }
-// 
-//       for (int i = 0; i < count; i++) {
-//       	new_words[i] = words[i];
-//       }
-// 
-//       free(words);
-//       words = new_words;
-//       buf = new_buf;
-//     }
-//     words[count] = word;
-//     count++;
-//     prev_word = word;
-//   }
-// 
-//   print_uniq(count, words, cflag);
-// 
-//   for (int i = 0; i < count; i++) {
-//   	free(words[i]);
-//   }
-//   free(words);
-}
-
-
-/*
 * creates a char * of all the lines from a given file and
 * prints out all the unique lines
 *
@@ -246,16 +163,6 @@ uniq(char *argv[], int fd)
       lines(fd, true);
       return;
     }
-
-    else if (!strcmp(argv[j], "-wc")) {
-      words(fd, true);
-      return;
-    }
-  
-    else if (!strcmp(argv[j], "-w")) {
-      words(fd, false);
-      return;
-    }
     j++;
   }
   
@@ -265,12 +172,22 @@ uniq(char *argv[], int fd)
 
 int main(int argc, char *argv[])
 {
-  if (argc < 1) {
-    printf("usage: uniq filename [-w] [-c] [-wc]\n");
-	return -1;
-  }
+  int fd = 0;
+  int arg_start = 1;
 
-  uniq(argv, 0);
+  if (argc > 1 && argv[1][0] != '-') {
+  	fd = open(argv[1], O_RDONLY);
+  	if (fd < 0) {
+    printf("cannot open file %s\n", argv[1]);
+	return -1;
+    }
+   arg_start = 2;
+  }
+  
+  uniq(&argv[arg_start], fd);
+
+  if (fd != 0) {
+  	close(fd);
+  }
   return 0;
 }
-

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -53,6 +53,30 @@ free_lines(int num_lines, char *lines[])
 }
 
 
+char 
+tolower(char c) 
+{
+	if (c >= 'A' && c <= 'Z') {
+	  return c + ('a' - 'A');
+	}
+	return c;
+}
+
+
+int
+strcmp_helper(const char *s1, const char *s2) {
+  while (*s1 && *s2) {
+    char c1 = tolower(*s1);
+    char c2 = tolower(*s2);
+    if (c1 != c2) {
+      return c1 - c2;
+    }
+    s1++;
+    s2++;
+  }
+  return tolower(*s1) - tolower(*s2);
+}
+
 /*
 * prints out the uniq instances from a provided sorted
 * char* array
@@ -62,7 +86,7 @@ free_lines(int num_lines, char *lines[])
 * @param cflag boolean for the -c flag
 */
 int 
-print_uniq(int count, char *lines[], bool cflag) 
+print_uniq(int count, char *lines[], bool cflag, bool fflag) 
 {
   int curr = 0; // keeps track of which line we're at
   int instances = 1; // keeps track of how many instances
@@ -75,20 +99,24 @@ print_uniq(int count, char *lines[], bool cflag)
        continue;
     }
 
-    if((curr + 1 < count) && strcmp(lines[curr], lines[curr + 1]) == 0) {
+    bool equal;
+    if (fflag) {
+    	equal = strcmp_helper(lines[curr], lines[curr + 1]) == 0;
+    } else {
+        equal = strcmp(lines[curr], lines[curr + 1]) == 0;
+    }
+
+    if((curr + 1 < count) && equal) {
       instances++;
-    }
-    // if we have hit the last uniq instance, print it out
-    else {
-      unique_count++;
-      if (cflag) { // with count
-        printf("%d %s", instances, lines[curr]);
-      }
-      else { // without count
-        printf("%s", lines[curr]);
-      }
+    } else {
+        unique_count++;
+        if (cflag) { // with count
+          printf("%d %s", instances, lines[curr]);
+        } else { // without count
+            printf("%s", lines[curr]);
+        }
       instances = 1;
-    }
+     }
 
     curr++;
   }
@@ -104,7 +132,7 @@ print_uniq(int count, char *lines[], bool cflag)
 * @param cflag boolean for the -c flag
 */
 void 
-lines(int fd, bool cflag, bool tflag) 
+lines(int fd, bool cflag, bool tflag, bool fflag) 
 {
   uint sz = 20; // getline will resize if necessary
   int buf = 0;
@@ -144,7 +172,7 @@ lines(int fd, bool cflag, bool tflag)
     lines[count] = line;
     count++;
   }
-  int unique_count = print_uniq(count, lines, cflag);
+  int unique_count = print_uniq(count, lines, cflag, fflag);
 
   if (tflag) {
   	printf("Total unique lines/words: %d\n", unique_count);
@@ -167,6 +195,7 @@ uniq(char *argv[], int fd)
   int j = 0;
   bool cflag = false;
   bool tflag = false; 
+  bool fflag = false;
 
   //FINDING PROPER FLAGS
   while (argv[j] != NULL) {
@@ -174,11 +203,13 @@ uniq(char *argv[], int fd)
       cflag = true;
     } else if (!strcmp(argv[j], "-t")) {
     	tflag = true;
+    } else if (!strcmp(argv[j], "-f")) {
+        fflag = true;
     }
     j++;
   }
   
-  lines(fd, cflag, tflag);
+  lines(fd, cflag, tflag, fflag);
 }
 
 

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -109,27 +109,49 @@ void print_uniq(int count, char *lines[], bool cflag) {
 */
 void lines(int fd, bool cflag) {
   uint sz = 20; // getline will resize if necessary
+  int buf = 0;
   int count = 0; // num of lines
-  char *lines[1024];
+  char **lines = 0;
 
-  while (true) {
+  while (1) {
+    if (count >= buf) {
+      uint new_buf;
+      if (buf == 0) {
+    	new_buf = 8;
+      } else {
+    	  new_buf = buf * 2;
+      }
+
+      char **new_lines = malloc(new_buf * sizeof(char *));
+      if (new_lines == 0) {
+      	printf("malloc failed");
+      	exit(1);
+      }
+      if (lines) {
+      	for (int i = 0; i < count; i++) {
+      		new_lines[i] = lines[i];
+      	}
+      	free(lines);
+      }
+      lines = new_lines;
+      buf = new_buf;
+    }
+
     char *line = malloc(sz);
     if (getline(&line, &sz, fd) <= 0) {
+      free(line);
       break;
     }
-    char *temp = malloc(sz);
-    memcpy(temp, line, sz);
-    free(line); // free old memory
-    lines[count] = temp;
-    line = temp;
+
+    lines[count] = line;
     count++;
-  } 
-  
-  bubble_sort(lines, count); // sort all the lines
-  print_uniq(count, lines, cflag); // print uniq instances
-  for (int i = 0; i < count; i++) {
-  	free(lines[i]);
   }
+    bubble_sort(lines, count);
+    print_uniq(count, lines, cflag);
+    
+    for (int i = 0; i < count; i++) {
+      free(lines[i]);
+    }
 }
 
 /*

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -1,0 +1,246 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+* helper function for sort that swaps two
+* values from an array
+*
+* @param array to swap in
+* @param i one index to swap
+* @param j other index to swap
+*/
+void
+swap(char * list[], int i, int j) {
+  char * temp = list[i];
+  list[i] = list[j];
+  list[j] = temp;
+}
+
+/*
+* bubble sorts an array of char *
+*
+* @param array to sort
+* @param length of array
+*/
+void
+bubble_sort(char *list[], int length) {
+  for (int i = 0; i < length; i++) {
+    for (int j = i + 1; j < length; j++) {
+      if (strcmp(list[i], list[j]) > 0) {
+        swap(list, i, j);
+      }
+    }
+  }
+}
+
+/*
+* writes a line word by word to a given file
+*
+* @param line to write
+* @param fd file descriptor to write to
+*/
+void *
+writewords(char *line, int fd){
+  // first char we check is the start of the line
+  char *character = &line[0];
+  while (*character != '\0') { // while we aren't at the end
+    if (*character == ' ' || *character == '\t') { // if we reach the end of a word
+      fprintf(fd, "\n");
+    }
+    else {
+      fprintf(fd, "%c", *character);
+    }
+    character++;
+  }
+
+  return 0;
+}
+
+
+/*
+* prints out the uniq instances from a provided sorted
+* char* array
+*
+* @param count max num of lines or words
+* @param lines array of lines or words
+* @param cflag boolean for the -c flag
+*/
+void print_uniq(int count, char *lines[], bool cflag) {
+  int curr = 0; // keeps track of which line we're at
+  int instances = 1; // keeps track of how many instances
+
+  while(curr < count) { // while we still have stuff to read
+    // skip null terms and line ends
+    if ((strcmp(lines[curr], "\0") == 0) || (strcmp(lines[curr], "\n") == 0)
+            || (strcmp(lines[curr], "\t") == 0)) {
+       continue;
+    }
+
+    if(strcmp(lines[curr], lines[curr + 1]) == 0){
+      instances++;
+    }
+    // if we have hit the last uniq instance, print it out
+    else {
+      if (cflag) { // with count
+        printf("%d %s", instances, lines[curr]);
+      }
+      else { // without count
+        printf("%s", lines[curr]);
+      }
+      instances = 1;
+    }
+
+    curr++;
+  }
+}
+
+
+/*
+* creates a char * of all the lines from a given file and
+* prints out all the unique lines
+*
+* @param fd file descriptor of file to read
+* @param cflag boolean for the -c flag
+*/
+void lines(int fd, bool cflag) {
+  uint sz = 20; // getline will resize if necessary
+  int count = 0; // num of lines
+  char *lines[1024];
+
+  while (true) {
+    char *line = malloc(sz);
+    if (getline(&line, &sz, fd) <= 0) {
+      break;
+    }
+    char *temp = malloc(sz);
+    memcpy(temp, line, sz);
+    free(line); // free old memory
+    lines[count] = temp;
+    line = temp;
+    count++;
+  } 
+  
+  bubble_sort(lines, count); // sort all the lines
+  print_uniq(count, lines, cflag); // print uniq instances
+  // free(lines);
+  for (int i = 0; i < count; i++) {
+  	free(lines[i]);
+  }
+}
+
+/*
+* creates a char * of all the words from a given file and
+* prints out all the unique words
+*
+* @param fd file descriptor of file to read
+* @param cflag boolean for the -c flag
+*/
+void words(int fd, bool cflag){
+  uint sz = 20; // getline will resize if necessary
+  int count = 0; // num of lines
+  // file we are writing the words to
+  int write = open("/temp.txt", O_CREATE | O_WRONLY);
+  if (write < 0) {
+    printf("error opening file: temp.txt\n");
+    return;
+  }
+
+  while (true) {
+    char *line = malloc(sz);
+    if (getline(&line, &sz, fd) <= 0) {
+      break;
+    }
+    char *temp = malloc(sz);
+    memcpy(temp, line, sz);
+    free(line); // free old memory
+
+    writewords(temp, write);
+    line = temp;
+    count++;
+  }
+  close(write);
+  // have to close & reopen file because xv6 hates us
+
+  // file to now read the words from
+  int read = open("/temp.txt", O_RDONLY);
+  if (read < 0) {
+    printf("error opening file: temp.txt\n");
+    return;
+  }
+
+	uint wordcount = 0; // num words
+  char *words[1024];
+  uint newsize = 10;
+
+  while (true) {
+    char *word = malloc(newsize);
+    if(getline(&word, &newsize, read) <= 0) {
+      break;
+    }
+    words[wordcount] = word;
+    wordcount++;
+  }
+
+  close(read);
+  bubble_sort(words, wordcount); // sort all the words
+  print_uniq(wordcount, words, cflag); // print unique words
+  for (int i = 0; i < wordcount; i++) {
+  	free(words[i]);
+  }
+  // free(words);
+}
+
+/*
+* creates a char * of all the lines from a given file and
+* prints out all the unique lines
+*
+* @param argv array of args to check for flags
+* @param fd file descriptor of file to read
+*/
+void
+uniq(char *argv[], int fd) {
+  int j = 0; 
+
+  //FINDING PROPER FLAGS
+  while (argv[j] != NULL) {
+    if (!strcmp(argv[j], "-c")) {
+      lines(fd, true);
+      return;
+    }
+
+    else if (!strcmp(argv[j], "-wc")) {
+      words(fd, true);
+      return;
+    }
+  
+    else if (!strcmp(argv[j], "-w")) {
+      words(fd, false);
+      return;
+    }
+    j++;
+  }
+  
+  lines(fd, false);
+}
+
+int main(int argc, char *argv[]){
+
+	if (argc < 2) {
+		printf("usage: uniq filename [-w] [-c] [-wc]\n");
+		return -1;
+	}
+
+  int fd = open(argv[1], O_RDONLY);
+  if (fd < 1) {
+  	printf("err opening file\n");
+  	return -1;
+  }
+  uniq(argv, fd);
+  return 0;
+
+}
+

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -32,8 +32,7 @@ writewords(char *line, int fd)
 
 
 /*
-* prints out the uniq instances from a provided sorted
-* char* array
+* frees memory allocated for the lines array
 *
 * @param num_lines max num of lines
 * @param lines array of lines
@@ -138,10 +137,8 @@ lines(int fd, bool cflag)
     count++;
   }
   print_uniq(count, lines, cflag);
-      
-  for (int i = 0; i < count; i++) {
-    free(lines[i]);
-  }
+
+  free_lines(count, lines);
 }
 
 

--- a/user/uniq.c
+++ b/user/uniq.c
@@ -49,10 +49,10 @@ writewords(char *line, int fd){
   char *character = &line[0];
   while (*character != '\0') { // while we aren't at the end
     if (*character == ' ' || *character == '\t') { // if we reach the end of a word
-      fprintf(fd, "\n");
+      write(fd, "\n", 1);
     }
     else {
-      fprintf(fd, "%c", *character);
+      write(fd, character, 1);
     }
     character++;
   }
@@ -77,10 +77,11 @@ void print_uniq(int count, char *lines[], bool cflag) {
     // skip null terms and line ends
     if ((strcmp(lines[curr], "\0") == 0) || (strcmp(lines[curr], "\n") == 0)
             || (strcmp(lines[curr], "\t") == 0)) {
+       curr++;
        continue;
     }
 
-    if(strcmp(lines[curr], lines[curr + 1]) == 0){
+    if((curr + 1 < count) && strcmp(lines[curr], lines[curr + 1]) == 0) {
       instances++;
     }
     // if we have hit the last uniq instance, print it out
@@ -126,7 +127,6 @@ void lines(int fd, bool cflag) {
   
   bubble_sort(lines, count); // sort all the lines
   print_uniq(count, lines, cflag); // print uniq instances
-  // free(lines);
   for (int i = 0; i < count; i++) {
   	free(lines[i]);
   }
@@ -172,7 +172,7 @@ void words(int fd, bool cflag){
     return;
   }
 
-	uint wordcount = 0; // num words
+	int wordcount = 0; // num words
   char *words[1024];
   uint newsize = 10;
 
@@ -188,10 +188,9 @@ void words(int fd, bool cflag){
   close(read);
   bubble_sort(words, wordcount); // sort all the words
   print_uniq(wordcount, words, cflag); // print unique words
-  for (int i = 0; i < wordcount; i++) {
-  	free(words[i]);
-  }
-  // free(words);
+  // for (int i = 0; i < wordcount; i++) {
+  //  	free(words[i]);
+  // }
 }
 
 /*

--- a/user/user.h
+++ b/user/user.h
@@ -1,3 +1,4 @@
+
 struct stat;
 
 // system calls
@@ -41,3 +42,4 @@ void free(void*);
 int atoi(const char*);
 int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);
+void uniq(char *argv[], int fd);

--- a/user/user.h
+++ b/user/user.h
@@ -43,5 +43,5 @@ int atoi(const char*);
 int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);
 void uniq(char *argv[], int fd);
-int sort(int fd, int num_flages, char*[]);
+int sort(int fd);
 void split(int fd, uint sz);

--- a/user/user.h
+++ b/user/user.h
@@ -43,3 +43,4 @@ int atoi(const char*);
 int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);
 void uniq(char *argv[], int fd);
+int sort(int fd, int num_flages, char*[]);

--- a/user/user.h
+++ b/user/user.h
@@ -44,3 +44,4 @@ int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);
 void uniq(char *argv[], int fd);
 int sort(int fd, int num_flages, char*[]);
+void split(int fd, uint sz);


### PR DESCRIPTION
[Issue #72](https://github.com/USF-OS/FogOS/issues/72)

## uniq Command

### Purpose
Reports or deletes repeated lines in a file.

### Syntax
`uniq [-c | -t | -f]`

### Description
The `uniq` command removes consecutive duplicate lines from a file. It reads input
from either standard input or a specified file and compares adjacent lines to eliminate
repeated occurrences. Because only adjacent duplicate lines are removed it is typically
used in conjunction with the `sort` command to ensure all duplicates are adjacent. The
unique lines are then written to standard output.

### Flags
- **-c**: prints the count of the unique lines
- **-t**: output the total number of unique lines or words at the end
- **-f**: allows the user to ignore case (case-insensitive comparison for uniqueness)

### Example
To remove repeated adjacent lines, enter:
`uniq README.md`

To remove nonadjacent repeated lines, enter:
`sort README.md | uniq` 

To remove nonadjacent repeated words, enter:
`split README.md | sort | uniq`

### Limitations
- The **-f** currently does not produce intended output on nonadjacent words.
- If the file being processed includes any empty lines the `uniq` command will break. The `split` command will fix this if pipped into `sort` then `uniq` but forces the user to specifically search for unique words rather than lines. 
- The `split` and `sort` commands currently do not support any flags.
- The `uniq` command cannot chain multiple flags together.