### PR TITLE
added df command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_df\
 
 fs.img: mkfs/mkfs README.md $(UPROGS)
 	mkfs/mkfs fs.img README.md $(UPROGS)

--- a/kernel/buf.h
+++ b/kernel/buf.h
@@ -1,3 +1,6 @@
+#ifndef BUF_H
+#define BUF_H
+
 struct buf {
   int valid;   // has data been read from disk?
   int disk;    // does disk "own" buf?
@@ -10,3 +13,4 @@ struct buf {
   uchar data[BSIZE];
 };
 
+#endif

--- a/kernel/file.h
+++ b/kernel/file.h
@@ -1,3 +1,5 @@
+#include "sleeplock.h"
+
 struct file {
   enum { FD_NONE, FD_PIPE, FD_INODE, FD_DEVICE } type;
   int ref; // reference count

--- a/kernel/fs.h
+++ b/kernel/fs.h
@@ -1,6 +1,10 @@
+#ifndef FS_H
+#define FS_H
+
 // On-disk file system format.
 // Both the kernel and user programs use this header file.
-
+int bmap_free_blocks(void);
+int free_inodes(void);
 
 #define ROOTINO  1   // root i-number
 #define BSIZE 1024  // block size
@@ -58,3 +62,4 @@ struct dirent {
   char name[DIRSIZ];
 };
 
+#endif

--- a/kernel/sleeplock.h
+++ b/kernel/sleeplock.h
@@ -1,3 +1,6 @@
+#ifndef SLEEPLOCK_H
+#define SLEEPLOCK_H
+
 // Long-term locks for processes
 struct sleeplock {
   uint locked;       // Is the lock held?
@@ -8,3 +11,4 @@ struct sleeplock {
   int pid;           // Process holding lock
 };
 
+#endif

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_statvfs(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_statvfs] sys_statvfs,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_statvfs 26

--- a/user/df.c
+++ b/user/df.c
@@ -1,0 +1,37 @@
+#include "user/user.h"
+#include "user/stat.h"
+#include "kernel/types.h"
+
+
+int main(int argc, char *argv[]) {
+    struct statvfs stats;
+    int human_readable = 0;
+    int inode_usage = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-h") == 0) {
+            human_readable = 1;
+        } else if (strcmp(argv[i], "-i") == 0) {
+            inode_usage = 1;
+        }
+    }
+
+    if (statvfs(&stats) < 0) {
+        printf("Error: Failed to retrieve filesystem stats\n");
+        exit(1);
+    }
+
+    if (inode_usage) {
+        printf("Inodes: Total: %d, Free: %d\n", stats.total_inodes, stats.free_inodes);
+    } else {
+        if (human_readable) {
+            printf("Disk: Total: %dKB, Used: %dKB, Free: %dKB\n",
+                   stats.total_blocks / 2, stats.used_blocks / 2, stats.free_blocks / 2);
+        } else {
+            printf("Disk: Total: %d blocks, Used: %d blocks, Free: %d blocks\n",
+                   stats.total_blocks, stats.used_blocks, stats.free_blocks);
+        }
+    }
+
+    return 0;
+}

--- a/user/stat.h
+++ b/user/stat.h
@@ -1,0 +1,12 @@
+#ifndef STAT_H
+#define STAT_H
+
+struct statvfs {
+    unsigned int total_blocks;
+    unsigned int free_blocks;
+    unsigned int used_blocks;
+    unsigned int total_inodes;
+    unsigned int free_inodes;
+};
+
+#endif

--- a/user/user.h
+++ b/user/user.h
@@ -1,5 +1,7 @@
 struct stat;
 
+typedef unsigned int uint;
+
 // system calls
 int fork(void);
 int exit(int) __attribute__((noreturn));
@@ -41,3 +43,4 @@ void free(void*);
 int atoi(const char*);
 int memcmp(const void *, const void *, uint);
 void *memcpy(void *, const void *, uint);
+int statvfs(void*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("statvfs");


### PR DESCRIPTION
The `df` command provides filesystem statistics such as total disk size, used space, available space, and inode information.

# Key Features:
## Basic Disk Usage Reporting:
The df command displays total blocks, used blocks, and free blocks for the entire filesystem. When run without arguments, it reports on all mounted filesystems. If one or more paths are provided, it reports only on the filesystems associated with those paths.

### Human-Readable Output (-h option):
Outputs sizes in KB, MB, GB, etc., making it easier to understand large filesystems.

### Inode Usage Information (-i option):
Displays inode usage instead of block usage, providing insight into the number of inodes available and used.

### Usage:
```
df           # Reports disk usage for all mounted filesystems.
df <path>    # Reports disk usage for the specified path's filesystem.
df -h        # Outputs disk usage in human-readable format (KB, MB, GB, etc.).
df -i        # Displays inode usage instead of block usage. 
```

### System Call Changes:
Added the statvfs system call to gather filesystem statistics from the kernel. This system call provides the df command with information about total blocks, free blocks, used blocks, total inodes, and free inodes.

### Future Development:
Add filters to report only on specific filesystem types (e.g., ext2, ext3, etc.).
Implement color-coded output to highlight filesystems that are nearing capacity.